### PR TITLE
ci: Protect package installs with Aikido Safe Chain

### DIFF
--- a/.github/actions/install-safe-chain/action.yml
+++ b/.github/actions/install-safe-chain/action.yml
@@ -1,26 +1,9 @@
-name: Setup
-description: Set up pnpm, Node.js, and Aikido Safe Chain so that subsequent package-manager commands are protected against malicious packages.
-
-inputs:
-  registry-url:
-    description: Optional npm registry URL to configure via actions/setup-node (used for publishing).
-    required: false
-    default: ""
+name: Install Aikido Safe Chain
+description: Install Aikido Safe Chain from a pinned release so that subsequent package-manager commands are guarded against malicious packages.
 
 runs:
   using: composite
   steps:
-    - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
-      with:
-        version: latest
-        run_install: false
-
-    - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-      with:
-        node-version-file: .nvmrc
-        cache: "pnpm"
-        registry-url: ${{ inputs.registry-url }}
-
     - name: Install Aikido Safe Chain
       shell: bash
       env:

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -23,4 +23,18 @@ runs:
 
     - name: Install Aikido Safe Chain
       shell: bash
-      run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
+      env:
+        # Pin both the release tag and the installer's SHA-256 so we don't blindly execute
+        # whatever is served by GitHub. Bump both together by downloading the new installer
+        # and taking its sha256 from the GitHub release asset API.
+        SAFE_CHAIN_VERSION: "1.4.7"
+        SAFE_CHAIN_INSTALLER_SHA256: "54c750232d149106ecf4f5f28fee82ba49d2428f1e411e0ed961c0263ae19eaf"
+      run: |
+        set -euo pipefail
+        installer="$(mktemp)"
+        trap 'rm -f "$installer"' EXIT
+        curl -fsSL \
+          "https://github.com/AikidoSec/safe-chain/releases/download/${SAFE_CHAIN_VERSION}/install-safe-chain.sh" \
+          -o "$installer"
+        echo "${SAFE_CHAIN_INSTALLER_SHA256}  ${installer}" | sha256sum -c -
+        sh "$installer" --ci

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,26 @@
+name: Setup
+description: Set up pnpm, Node.js, and Aikido Safe Chain so that subsequent package-manager commands are protected against malicious packages.
+
+inputs:
+  registry-url:
+    description: Optional npm registry URL to configure via actions/setup-node (used for publishing).
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+      with:
+        version: latest
+        run_install: false
+
+    - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+      with:
+        node-version-file: .nvmrc
+        cache: "pnpm"
+        registry-url: ${{ inputs.registry-url }}
+
+    - name: Install Aikido Safe Chain
+      shell: bash
+      run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,15 +21,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
-        with:
-          version: latest
-          run_install: false
-
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-        with:
-          node-version-file: .nvmrc
-          cache: "pnpm"
+      - uses: ./.github/actions/setup
 
       - name: Install dependencies
         run: pnpm install
@@ -52,15 +44,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
-        with:
-          version: latest
-          run_install: false
-
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-        with:
-          node-version-file: .nvmrc
-          cache: "pnpm"
+      - uses: ./.github/actions/setup
 
       - name: Install dependencies
         run: pnpm install
@@ -105,16 +89,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+      - uses: ./.github/actions/setup
         with:
-          version: latest
-          run_install: false
-
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-        with:
-          node-version-file: .nvmrc
-          cache: "pnpm"
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
 
       # Ensure npm 11.5.1 or later is installed for trusted publishing
       - name: Update npm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,17 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: ./.github/actions/setup
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+        with:
+          version: latest
+          run_install: false
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version-file: .nvmrc
+          cache: "pnpm"
+
+      - uses: ./.github/actions/install-safe-chain
 
       - name: Install dependencies
         run: pnpm install
@@ -44,7 +54,17 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: ./.github/actions/setup
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+        with:
+          version: latest
+          run_install: false
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version-file: .nvmrc
+          cache: "pnpm"
+
+      - uses: ./.github/actions/install-safe-chain
 
       - name: Install dependencies
         run: pnpm install
@@ -89,9 +109,18 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: ./.github/actions/setup
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
         with:
-          registry-url: "https://registry.npmjs.org"
+          version: latest
+          run_install: false
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version-file: .nvmrc
+          cache: "pnpm"
+          registry-url: 'https://registry.npmjs.org'
+
+      - uses: ./.github/actions/install-safe-chain
 
       # Ensure npm 11.5.1 or later is installed for trusted publishing
       - name: Update npm


### PR DESCRIPTION
Install Aikido Safe Chain in CI before any package-manager commands so that npm/pnpm invocations are guarded against malicious packages. The pnpm/Node setup plus Safe Chain install is extracted into a reusable composite action at .github/actions/setup to avoid duplication across the test, build-demo, and release jobs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Created a new composite GitHub Action to consolidate build environment setup across CI workflows.
  * Updated CI jobs to use the new setup action, reducing configuration redundancy.
  * Added an optional registry configuration parameter for flexible npm package source management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->