### PR TITLE
fix: Accept plain CSS color values in the `color` prop

### DIFF
--- a/.changeset/fair-pugs-hear.md
+++ b/.changeset/fair-pugs-hear.md
@@ -1,0 +1,5 @@
+---
+"slidev-addon-fancy-arrow": minor
+---
+
+Accept plain CSS color values such as `var(--my-color)`, `#ff8800`, and `rgb(255 136 0)` in the `color` prop. Previously the prop only became a `text-*` UnoCSS class, which took effect only for the tokens UnoCSS happened to generate a utility for. UnoCSS tokens keep rendering exactly as before.

--- a/README.md
+++ b/README.md
@@ -90,7 +90,9 @@ See also: https://sli.dev/guide/theme-addon#use-addon
 <FancyArrow color="rgb(255 136 0)" from="(100, 200)" to="(300, 400)" />
 ```
 
-A UnoCSS token takes effect only when UnoCSS generates the matching `text-*` utility, and it does not always do so for a token that appears in this prop alone. A CSS color value has no such caveat, so prefer it when a token has no effect.
+A UnoCSS token takes effect only when UnoCSS generates the matching `text-*` utility, and it does not always do so for a token that appears in this prop alone. To force one, add it to `safelist` in your deck's `uno.config.ts`, or use it as a class somewhere in the deck.
+
+A CSS color value has no such caveat, so prefer it when a token has no effect. Note that for a name that is both a CSS color and a UnoCSS token, such as `orange` or `lime`, the token wins wherever UnoCSS generated the utility, so reach for an unambiguous form like `#a3e635` or `var(--my-color)` when the exact color matters.
 
 ### Animation
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,19 @@ See also: https://sli.dev/guide/theme-addon#use-addon
 />
 ```
 
+#### Color
+
+`color` accepts either a [UnoCSS](https://unocss.dev/) color token or a plain CSS color value.
+
+```html
+<FancyArrow color="orange" from="(100, 200)" to="(300, 400)" />
+<FancyArrow color="#ff8800" from="(100, 200)" to="(300, 400)" />
+<FancyArrow color="var(--my-color)" from="(100, 200)" to="(300, 400)" />
+<FancyArrow color="rgb(255 136 0)" from="(100, 200)" to="(300, 400)" />
+```
+
+A UnoCSS token takes effect only when UnoCSS generates the matching `text-*` utility, and it does not always do so for a token that appears in this prop alone. A CSS color value has no such caveat, so prefer it when a token has no effect.
+
 ### Animation
 
 #### Animation properties

--- a/components/FancyArrow.vue
+++ b/components/FancyArrow.vue
@@ -222,9 +222,17 @@ const { arrowSvg, textPosition } = useRoughArrow({
       <slot name="head" />
     </ChildElementPicker>
 
+    <!--
+    The paths stroke and fill with `currentColor`, and `color` may be either a UnoCSS color
+    token (`orange`, `red-500`) or a plain CSS color value (`var(--my-color)`, `#f00`).
+    Both forms are emitted and the cascade resolves which one is real: the raw value sits on
+    the `<svg>` to be inherited and is dropped when it isn't valid CSS, while the `text-*`
+    class on the inner `<g>` overrides that inherited value when UnoCSS generated the
+    matching utility.
+  -->
     <svg
       ref="svgContainer"
-      :class="props.color ? `text-${props.color}` : ''"
+      :style="{ color: props.color }"
       style="
         position: absolute;
         top: 0;
@@ -235,7 +243,7 @@ const { arrowSvg, textPosition } = useRoughArrow({
       "
     >
       <!-- eslint-disable-next-line vue/no-v-html -->
-      <g v-html="arrowSvg" />
+      <g :class="props.color ? `text-${props.color}` : ''" v-html="arrowSvg" />
     </svg>
     <div
       v-if="$slots.default && textPosition"

--- a/components/FancyArrow.vue
+++ b/components/FancyArrow.vue
@@ -224,12 +224,10 @@ const { arrowSvg, textPosition } = useRoughArrow({
 
     <!--
     The paths stroke and fill with `currentColor`, and `color` may be either a UnoCSS color
-    token (`orange`, `red-500`) or a plain CSS color value (`var(--my-color)`, `#f00`).
-    Both forms are emitted and the cascade resolves which one is real: the raw value sits on
-    the `<svg>` to be inherited and is dropped when it isn't valid CSS, while the `text-*`
-    class on the inner `<g>` overrides that inherited value when UnoCSS generated the
-    matching utility.
-  -->
+    token or a plain CSS color value, which can't be told apart reliably. So both forms are
+    emitted and the cascade resolves it: an invalid CSS value is dropped by the browser, and
+    the inner `text-*` class wins over the inherited value when UnoCSS generated the utility.
+    -->
     <svg
       ref="svgContainer"
       :style="{ color: props.color }"

--- a/slides.md
+++ b/slides.md
@@ -401,10 +401,10 @@ If no snap target or absolute position is specified, the arrow will automaticall
     color="orange"
 />
 <FancyArrow x1="140" y1="180" x2="240" y2="280"
-    color="lime"
+    color="#a3e635"
 />
 <FancyArrow x1="180" y1="180" x2="280" y2="280"
-    color="cyan"
+    color="var(--slidev-theme-primary)"
 />
 
 <div grow-1><!-- Placeholder--></div>
@@ -414,10 +414,10 @@ If no snap target or absolute position is specified, the arrow will automaticall
     color="orange"
 />
 <FancyArrow x1="140" y1="180" x2="240" y2="280"
-    color="lime"
+    color="#a3e635"
 />
 <FancyArrow x1="180" y1="180" x2="280" y2="280"
-    color="cyan"
+    color="var(--slidev-theme-primary)"
 />
 ```
 


### PR DESCRIPTION
The `color` prop only ever became a `text-${color}` UnoCSS class, so `color="var(--my-color)"` produced no CSS at all. UnoCSS generates a `.text-*` utility only for tokens it finds while scanning source, and the `[color~="..."]` attributify selector it generates from the markdown never matches, because `color` is a declared prop that Vue does not pass through to the DOM. The tokens that did work (`orange`, `green`, `blue`) worked incidentally, because those class names happen to appear in scanned sources; `fuchsia`, `#ff8800` and `red-500/50` were all silently ignored.

Both forms are now emitted and the cascade resolves which one is real. The raw value sits on the `<svg>` as an inherited `color` and is dropped by the browser when it is not valid CSS, while the `text-*` class moves to the inner `<g>`, where it overrides the inherited value when UnoCSS generated the matching utility. The value is never inspected to guess which kind it is, and UnoCSS tokens keep rendering exactly as before, so existing decks are unaffected.

A consequence is that a token still wins over a CSS value for a name that is both, so `color="orange"` remains UnoCSS's `orange-400` rather than CSS `orange`. Letting the CSS value win would be a cleaner rule but would shift colors in every existing deck. The `README.md` section documents that, along with `safelist` as the way to force a utility UnoCSS skipped.

The demo deck's Appearance slide now shows one token alongside `#a3e635` and `var(--slidev-theme-primary)`, so the newly accepted forms appear in the live docs. The `#a3e635` arrow renders the same color as the `lime` token it replaces; the `var(--slidev-theme-primary)` one is a new color.

Closes #375


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for CSS color values, including hex codes and CSS variables, in the arrow `color` prop.
  - Existing UnoCSS color tokens remain supported.

- **Documentation**
  - Documented supported color formats, usage examples, UnoCSS safelist requirements, and precedence guidance.
  - Updated color examples to demonstrate CSS color values and theme variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->