### PR TITLE
fix(ci): Run esbuild's build script under pnpm 11 via `allowBuilds`

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
+packages: []
 onlyBuiltDependencies:
   - esbuild

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,7 @@
 packages: []
+allowBuilds:
+  esbuild: true
+# pnpm 11 renamed `allowBuilds` from `onlyBuiltDependencies` and ignores the old key
+# without warning. Both are kept so the build runs on pnpm 9, 10 and 11 alike.
 onlyBuiltDependencies:
   - esbuild


### PR DESCRIPTION
pnpm 11 renamed the build allowlist from `onlyBuiltDependencies` to `allowBuilds`, and it no longer gates builds on the old key or warns that the key is being ignored. esbuild's build script is therefore skipped, and `pnpm install` exits with `ERR_PNPM_IGNORED_BUILDS`. CI installs pnpm with `version: latest`, so every job on `main` currently fails at the install step with no repository change involved.

`pnpm-workspace.yaml` now carries `allowBuilds`, keeping `onlyBuiltDependencies` beside it so the build still runs for anyone on pnpm 9 or 10. It also gains an empty `packages` field, which pnpm 9 requires before it will read the file at all.

Installing esbuild 0.27.7 against this file exits 0 and runs its postinstall on both pnpm 9.15.9 and 11.21.0, which the CI run here only covers for `latest`. Against `main`'s current file, pnpm 11.21.0 exits 1 with `ERR_PNPM_IGNORED_BUILDS`.
