### PR TITLE
feat: Add a `line-style` prop for dashed and dotted arrows

### DIFF
--- a/.changeset/spotty-pugs-dance.md
+++ b/.changeset/spotty-pugs-dance.md
@@ -1,0 +1,5 @@
+---
+"slidev-addon-fancy-arrow": minor
+---
+
+Add a `line-style` prop accepting `solid` (the default), `dashed`, and `dotted`. The dash pattern scales with `width` and applies to the line only, leaving the arrow head solid, and dashed lines keep the stroke-drawing animation.

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ See also: https://sli.dev/guide/theme-addon#use-addon
 <FancyArrow
   color="orange"
   width="4"
+  line-style="dashed"
   two-way
   head-type="polygon"
   head-size="40"
@@ -93,6 +94,17 @@ See also: https://sli.dev/guide/theme-addon#use-addon
 A UnoCSS token takes effect only when UnoCSS generates the matching `text-*` utility, and it does not always do so for a token that appears in this prop alone. To force one, add it to `safelist` in your deck's `uno.config.ts`, or use it as a class somewhere in the deck.
 
 A CSS color value has no such caveat, so prefer it when a token has no effect. Note that for a name that is both a CSS color and a UnoCSS token, such as `orange` or `lime`, the token wins wherever UnoCSS generated the utility, so reach for an unambiguous form like `#a3e635` or `var(--my-color)` when the exact color matters.
+
+#### Line style
+
+`line-style` accepts `solid` (the default), `dashed`, or `dotted`.
+
+```html
+<FancyArrow line-style="dashed" from="(100, 200)" to="(300, 400)" />
+<FancyArrow line-style="dotted" from="(100, 200)" to="(300, 400)" />
+```
+
+The dash pattern scales with `width`, and applies to the line only so that the arrow head stays readable at any size.
 
 ### Animation
 

--- a/components/FancyArrow.vue
+++ b/components/FancyArrow.vue
@@ -11,7 +11,11 @@ import {
   SnapTarget,
   computeEndpointPosition,
 } from "./position";
-import { useRoughArrow, DEFAULT_ANIMATION_DURATION } from "./use-rough-arrow";
+import {
+  useRoughArrow,
+  DEFAULT_ANIMATION_DURATION,
+  type LineStyle,
+} from "./use-rough-arrow";
 import ChildElementPicker from "./ChildElementPicker.vue";
 
 const props = defineProps<{
@@ -28,6 +32,7 @@ const props = defineProps<{
   x2?: number | string;
   y2?: number | string;
   width?: number | string;
+  lineStyle?: LineStyle;
   color?: string;
   twoWay?: boolean;
   arc?: number | string;
@@ -178,6 +183,7 @@ const { arrowSvg, textPosition } = useRoughArrow({
   point1: tailAbsPos,
   point2: headAbsPos,
   width: () => Number(props.width ?? 2),
+  lineStyle: () => props.lineStyle ?? "solid",
   twoWay: () => props.twoWay ?? false,
   centerPositionParam: () => Number(props.arc ?? 0),
   headType: () => props.headType ?? "line",

--- a/components/path-bounds.test.ts
+++ b/components/path-bounds.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { getPathControlPointBounds } from "./path-bounds";
+
+describe("getPathControlPointBounds", () => {
+  it("covers the control points of every given path", () => {
+    expect(
+      getPathControlPointBounds([
+        "M10 20 C30 40, 50 60, 70 80",
+        "M-5 100 L15 -25",
+      ]),
+    ).toEqual({ x: -5, y: -25, width: 75, height: 125 });
+  });
+
+  it("parses decimal and exponential coordinates", () => {
+    expect(getPathControlPointBounds(["M-.5 1.5e2 L2.25 -1E1"])).toEqual({
+      x: -0.5,
+      y: -10,
+      width: 2.75,
+      height: 160,
+    });
+  });
+
+  it("returns null when there is nothing to measure", () => {
+    expect(getPathControlPointBounds([])).toBeNull();
+    expect(getPathControlPointBounds([""])).toBeNull();
+  });
+});

--- a/components/path-bounds.ts
+++ b/components/path-bounds.ts
@@ -11,7 +11,7 @@ const NUMBER_PATTERN = /-?\d*\.?\d+(?:[eE][-+]?\d+)?/g;
  * Bounding box of the control points of the given path definitions.
  *
  * Rough.js emits only `M`, `L`, and `C` commands with absolute coordinate pairs
- * (https://github.com/rough-stuff/rough/blob/v4.6.6/src/generator.ts#L227-L241),
+ * (https://github.com/rough-stuff/rough/blob/b674e17f68d3ae79d124304978f8e78f16ee71fd/src/generator.ts#L238-L248),
  * and a bezier curve never leaves the convex hull of its control points, so the
  * box is guaranteed to contain the rendered path.
  */

--- a/components/path-bounds.ts
+++ b/components/path-bounds.ts
@@ -1,0 +1,46 @@
+export interface Bounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+const NUMBER_PATTERN = /-?\d*\.?\d+(?:[eE][-+]?\d+)?/g;
+
+/**
+ * Bounding box of the control points of the given path definitions.
+ *
+ * Rough.js emits only `M`, `L`, and `C` commands with absolute coordinate pairs
+ * (https://github.com/rough-stuff/rough/blob/v4.6.6/src/generator.ts#L227-L241),
+ * and a bezier curve never leaves the convex hull of its control points, so the
+ * box is guaranteed to contain the rendered path.
+ */
+export function getPathControlPointBounds(
+  pathDefinitions: string[],
+): Bounds | null {
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+
+  for (const d of pathDefinitions) {
+    const numbers = d.match(NUMBER_PATTERN);
+    if (numbers == null) {
+      continue;
+    }
+    for (let i = 0; i + 1 < numbers.length; i += 2) {
+      const x = Number(numbers[i]);
+      const y = Number(numbers[i + 1]);
+      minX = Math.min(minX, x);
+      minY = Math.min(minY, y);
+      maxX = Math.max(maxX, x);
+      maxY = Math.max(maxY, y);
+    }
+  }
+
+  if (minX > maxX) {
+    return null;
+  }
+
+  return { x: minX, y: minY, width: maxX - minX, height: maxY - minY };
+}

--- a/components/split-path.ts
+++ b/components/split-path.ts
@@ -3,6 +3,14 @@ export function splitPathDefinition(d: string): string[] {
   return segments.map((s) => s.trim()).filter((s) => s !== "");
 }
 
+export function clonePath(path: SVGPathElement): SVGPathElement {
+  const cloned = path.cloneNode();
+  if (!(cloned instanceof SVGPathElement)) {
+    throw new Error("Expected cloneNode() to return an SVGPathElement");
+  }
+  return cloned;
+}
+
 export function splitPath(path: SVGPathElement): SVGPathElement[] {
   // Split <path d="M ... M ..." /> into <path d="M ..." /> elements.
   const d = path.getAttribute("d");
@@ -10,10 +18,7 @@ export function splitPath(path: SVGPathElement): SVGPathElement[] {
     return [];
   }
   return splitPathDefinition(d).map((segment) => {
-    const cloned = path.cloneNode();
-    if (!(cloned instanceof SVGPathElement)) {
-      throw new Error("Expected cloneNode() to return an SVGPathElement");
-    }
+    const cloned = clonePath(path);
     cloned.setAttribute("d", segment);
     return cloned;
   });

--- a/components/use-rough-arrow.ts
+++ b/components/use-rough-arrow.ts
@@ -1,6 +1,6 @@
 import { computed, toValue, useId, type MaybeRefOrGetter, type Ref } from "vue";
 import roughjs from "roughjs";
-import { splitPath } from "./split-path";
+import { clonePath, splitPath } from "./split-path";
 import { getPathControlPointBounds } from "./path-bounds";
 
 type RoughSVG = ReturnType<typeof roughjs.svg>;
@@ -25,14 +25,6 @@ function getStrokeLineDash(
     return [0, width * 2.5];
   }
   return undefined;
-}
-
-function clonePath(path: SVGPathElement): SVGPathElement {
-  const cloned = path.cloneNode();
-  if (!(cloned instanceof SVGPathElement)) {
-    throw new Error("Expected cloneNode() to return an SVGPathElement");
-  }
-  return cloned;
 }
 
 const createArrowHeadSvg = (
@@ -340,8 +332,10 @@ export function useRoughArrow(props: {
 
     const maskStrokeWidth = toValue(props.width) * 2;
     const animatedPaths = linePaths.map((path) => {
+      // The clone carries rough.js's `stroke-dasharray` attribute along with the
+      // rest, and the animation's inline one overrides it, so the mask stroke that
+      // does the revealing is solid.
       const cloned = clonePath(path);
-      cloned.removeAttribute("stroke-dasharray");
       cloned.setAttribute("stroke", "#fff");
       cloned.setAttribute("stroke-width", `${maskStrokeWidth}`);
       cloned.setAttribute("stroke-linecap", "round");

--- a/components/use-rough-arrow.ts
+++ b/components/use-rough-arrow.ts
@@ -1,10 +1,39 @@
-import { computed, toValue, type MaybeRefOrGetter, type Ref } from "vue";
+import { computed, toValue, useId, type MaybeRefOrGetter, type Ref } from "vue";
 import roughjs from "roughjs";
 import { splitPath } from "./split-path";
+import { getPathControlPointBounds } from "./path-bounds";
 
 type RoughSVG = ReturnType<typeof roughjs.svg>;
 
+const SVGNS = "http://www.w3.org/2000/svg";
+
 export const DEFAULT_ANIMATION_DURATION = 800; // Same as https://github.com/rough-stuff/rough-notation/blob/668ba82ac89c903d6f59c9351b9b85855da9882c/src/model.ts#L3C14-L3C47
+
+export type LineStyle = "solid" | "dashed" | "dotted";
+
+// The pattern scales with the stroke width so that it reads the same at any width.
+function getStrokeLineDash(
+  lineStyle: LineStyle,
+  width: number,
+): number[] | undefined {
+  if (lineStyle === "dashed") {
+    return [width * 4, width * 3];
+  }
+  if (lineStyle === "dotted") {
+    // A zero-length dash renders as a dot only with a round line cap,
+    // which the caller applies to the path.
+    return [0, width * 2.5];
+  }
+  return undefined;
+}
+
+function clonePath(path: SVGPathElement): SVGPathElement {
+  const cloned = path.cloneNode();
+  if (!(cloned instanceof SVGPathElement)) {
+    throw new Error("Expected cloneNode() to return an SVGPathElement");
+  }
+  return cloned;
+}
 
 const createArrowHeadSvg = (
   roughSvg: RoughSVG,
@@ -19,7 +48,7 @@ const createArrowHeadSvg = (
   const x2 = -lineLength * Math.cos(arrowAngle);
   const y2 = lineLength * Math.sin(-arrowAngle);
 
-  const g = document.createElementNS("http://www.w3.org/2000/svg", "g");
+  const g = document.createElementNS(SVGNS, "g");
 
   function addAllChildren(anotherGroup: SVGGElement) {
     // `for (... of anotherGroup.children)` doesn't work well: the second child and the latter will be discarded somehow.
@@ -57,6 +86,7 @@ export function useRoughArrow(props: {
   point1: Ref<AbsolutePosition | undefined>;
   point2: Ref<AbsolutePosition | undefined>;
   width: MaybeRefOrGetter<number>;
+  lineStyle: MaybeRefOrGetter<LineStyle>;
   headType: MaybeRefOrGetter<"line" | "polygon">;
   headSize: MaybeRefOrGetter<number | null>;
   roughness?: MaybeRefOrGetter<number | undefined>;
@@ -92,9 +122,12 @@ export function useRoughArrow(props: {
       ...(seed !== undefined && { seed }),
     };
   }
-  const roughSvg = roughjs.svg(
-    document.createElementNS("http://www.w3.org/2000/svg", "svg"),
+  const roughSvg = roughjs.svg(document.createElementNS(SVGNS, "svg"));
+
+  const strokeLineDash = computed(() =>
+    getStrokeLineDash(toValue(props.lineStyle), toValue(props.width)),
   );
+  const lineMaskId = `fancy-arrow-line-mask-${useId()}`;
 
   const arcData = computed(() => {
     if (!point1Ref.value || !point2Ref.value) {
@@ -113,6 +146,9 @@ export function useRoughArrow(props: {
 
     const lineOptions = {
       ...getBaseOptions(),
+      ...(strokeLineDash.value !== undefined && {
+        strokeLineDash: strokeLineDash.value,
+      }),
       stroke: "currentColor",
       strokeWidth: width,
     };
@@ -288,8 +324,50 @@ export function useRoughArrow(props: {
     return { arrowHeadBackwardSvg, arrowHeadForwardSvg, lineLength };
   });
 
+  // The stroke-drawing animation and a dash pattern both live in `stroke-dasharray`,
+  // so they can't share one element. The animation is moved onto white copies of the
+  // line inside a <mask>, and the dashed line is revealed through it as they are drawn.
+  function buildLineMask(linePaths: SVGPathElement[]): {
+    maskElement: SVGMaskElement;
+    animatedPaths: SVGPathElement[];
+  } | null {
+    const bounds = getPathControlPointBounds(
+      linePaths.map((path) => path.getAttribute("d") ?? ""),
+    );
+    if (bounds == null) {
+      return null;
+    }
+
+    const maskStrokeWidth = toValue(props.width) * 2;
+    const animatedPaths = linePaths.map((path) => {
+      const cloned = clonePath(path);
+      cloned.removeAttribute("stroke-dasharray");
+      cloned.setAttribute("stroke", "#fff");
+      cloned.setAttribute("stroke-width", `${maskStrokeWidth}`);
+      cloned.setAttribute("stroke-linecap", "round");
+      cloned.setAttribute("stroke-linejoin", "round");
+      return cloned;
+    });
+
+    const maskElement = document.createElementNS(SVGNS, "mask");
+    maskElement.setAttribute("id", lineMaskId);
+    // The default mask region is relative to the bounding box, which collapses for a
+    // horizontal or vertical line, so the region is spelled out in user space instead.
+    maskElement.setAttribute("maskUnits", "userSpaceOnUse");
+    // The mask stroke spreads half its width to either side of the geometry,
+    // and the region is padded by the whole width to leave slack.
+    const padding = maskStrokeWidth;
+    maskElement.setAttribute("x", `${bounds.x - padding}`);
+    maskElement.setAttribute("y", `${bounds.y - padding}`);
+    maskElement.setAttribute("width", `${bounds.width + padding * 2}`);
+    maskElement.setAttribute("height", `${bounds.height + padding * 2}`);
+    animatedPaths.forEach((path) => maskElement.appendChild(path));
+
+    return { maskElement, animatedPaths };
+  }
+
   const arrowSvg = computed(() => {
-    const g = document.createElementNS("http://www.w3.org/2000/svg", "g");
+    const g = document.createElementNS(SVGNS, "g");
 
     if (arcData.value == null || arrowHeadData.value == null) {
       return null;
@@ -303,7 +381,27 @@ export function useRoughArrow(props: {
     // Such paths don't be animated as expected, so we split them into multiple <path> elements that only contain `d` with only one `M`
     // and animate them individually.
     const splitPaths = splitPath(arcPath);
-    splitPaths.forEach((path) => g.appendChild(path));
+    if (toValue(props.lineStyle) === "dotted") {
+      splitPaths.forEach((path) =>
+        path.setAttribute("stroke-linecap", "round"),
+      );
+    }
+
+    const lineMask =
+      strokeLineDash.value !== undefined && animation.value
+        ? buildLineMask(splitPaths)
+        : null;
+    if (lineMask) {
+      const maskedGroup = document.createElementNS(SVGNS, "g");
+      maskedGroup.setAttribute("mask", `url(#${lineMaskId})`);
+      splitPaths.forEach((path) => maskedGroup.appendChild(path));
+      g.appendChild(lineMask.maskElement);
+      g.appendChild(maskedGroup);
+    } else {
+      splitPaths.forEach((path) => g.appendChild(path));
+    }
+    const animatedLinePaths = lineMask?.animatedPaths ?? splitPaths;
+
     g.appendChild(arrowHeadForwardSvg);
     if (arrowHeadBackwardSvg) {
       g.appendChild(arrowHeadBackwardSvg);
@@ -321,7 +419,7 @@ export function useRoughArrow(props: {
 
       segments.push({
         length: arcData.value.lineLength,
-        strokedPaths: splitPaths,
+        strokedPaths: animatedLinePaths,
         filledPaths: [],
       });
 

--- a/components/use-rough-arrow.ts
+++ b/components/use-rough-arrow.ts
@@ -20,8 +20,8 @@ function getStrokeLineDash(
     return [width * 4, width * 3];
   }
   if (lineStyle === "dotted") {
-    // A zero-length dash renders as a dot only with a round line cap,
-    // which the caller applies to the path.
+    // A zero-length dash renders as a dot only with a round line cap, which
+    // applyLineStyle pairs with it.
     return [0, width * 2.5];
   }
   return undefined;
@@ -138,9 +138,6 @@ export function useRoughArrow(props: {
 
     const lineOptions = {
       ...getBaseOptions(),
-      ...(strokeLineDash.value !== undefined && {
-        strokeLineDash: strokeLineDash.value,
-      }),
       stroke: "currentColor",
       strokeWidth: width,
     };
@@ -316,6 +313,24 @@ export function useRoughArrow(props: {
     return { arrowHeadBackwardSvg, arrowHeadForwardSvg, lineLength };
   });
 
+  // The dash pattern is set here rather than handed to rough.js as `strokeLineDash`,
+  // which would make arcData depend on the line style and re-roughen the line on every
+  // change. Rough.js only forwards that option to this same attribute.
+  function applyLineStyle(linePaths: SVGPathElement[]): void {
+    const lineDash = strokeLineDash.value;
+    if (lineDash === undefined) {
+      return;
+    }
+    const dashArray = lineDash.join(" ");
+    const lineCap = toValue(props.lineStyle) === "dotted" ? "round" : null;
+    for (const path of linePaths) {
+      path.setAttribute("stroke-dasharray", dashArray);
+      if (lineCap != null) {
+        path.setAttribute("stroke-linecap", lineCap);
+      }
+    }
+  }
+
   // The stroke-drawing animation and a dash pattern both live in `stroke-dasharray`,
   // so they can't share one element. The animation is moved onto white copies of the
   // line inside a <mask>, and the dashed line is revealed through it as they are drawn.
@@ -330,11 +345,13 @@ export function useRoughArrow(props: {
       return null;
     }
 
+    // Twice the line width so the revealed stroke sits clear of the mask edge,
+    // where antialiasing would dim it.
     const maskStrokeWidth = toValue(props.width) * 2;
     const animatedPaths = linePaths.map((path) => {
-      // The clone carries rough.js's `stroke-dasharray` attribute along with the
-      // rest, and the animation's inline one overrides it, so the mask stroke that
-      // does the revealing is solid.
+      // The clone carries the dash pattern along with the rest, and the animation's
+      // inline `stroke-dasharray` overrides it, so the mask stroke that does the
+      // revealing is solid.
       const cloned = clonePath(path);
       cloned.setAttribute("stroke", "#fff");
       cloned.setAttribute("stroke-width", `${maskStrokeWidth}`);
@@ -375,11 +392,7 @@ export function useRoughArrow(props: {
     // Such paths don't be animated as expected, so we split them into multiple <path> elements that only contain `d` with only one `M`
     // and animate them individually.
     const splitPaths = splitPath(arcPath);
-    if (toValue(props.lineStyle) === "dotted") {
-      splitPaths.forEach((path) =>
-        path.setAttribute("stroke-linecap", "round"),
-      );
-    }
+    applyLineStyle(splitPaths);
 
     const lineMask =
       strokeLineDash.value !== undefined && animation.value

--- a/slides.md
+++ b/slides.md
@@ -495,9 +495,15 @@ If no snap target or absolute position is specified, the arrow will automaticall
 
 ### Solid
 
-<FancyArrow x1="100" y1="180" x2="200" y2="280" width="2" line-style="solid" />
-<FancyArrow x1="140" y1="180" x2="240" y2="280" width="4" line-style="solid" />
-<FancyArrow x1="180" y1="180" x2="280" y2="280" width="6" line-style="solid" />
+<FancyArrow x1="100" y1="180" x2="200" y2="280" width="2"
+    line-style="solid"
+/>
+<FancyArrow x1="140" y1="180" x2="240" y2="280" width="4"
+    line-style="solid"
+/>
+<FancyArrow x1="180" y1="180" x2="280" y2="280" width="6"
+    line-style="solid"
+/>
 
 <div grow-1><!-- Placeholder--></div>
 
@@ -519,9 +525,15 @@ If no snap target or absolute position is specified, the arrow will automaticall
 
 ### Dashed
 
-<FancyArrow x1="400" y1="180" x2="500" y2="280" width="2" line-style="dashed" />
-<FancyArrow x1="440" y1="180" x2="540" y2="280" width="4" line-style="dashed" />
-<FancyArrow x1="480" y1="180" x2="580" y2="280" width="6" line-style="dashed" />
+<FancyArrow x1="400" y1="180" x2="500" y2="280" width="2"
+    line-style="dashed"
+/>
+<FancyArrow x1="440" y1="180" x2="540" y2="280" width="4"
+    line-style="dashed"
+/>
+<FancyArrow x1="480" y1="180" x2="580" y2="280" width="6"
+    line-style="dashed"
+/>
 
 <div grow-1><!-- Placeholder--></div>
 
@@ -543,9 +555,15 @@ If no snap target or absolute position is specified, the arrow will automaticall
 
 ### Dotted
 
-<FancyArrow x1="700" y1="180" x2="800" y2="280" width="2" line-style="dotted" />
-<FancyArrow x1="740" y1="180" x2="840" y2="280" width="4" line-style="dotted" />
-<FancyArrow x1="780" y1="180" x2="880" y2="280" width="6" line-style="dotted" />
+<FancyArrow x1="700" y1="180" x2="800" y2="280" width="2"
+    line-style="dotted"
+/>
+<FancyArrow x1="740" y1="180" x2="840" y2="280" width="4"
+    line-style="dotted"
+/>
+<FancyArrow x1="780" y1="180" x2="880" y2="280" width="6"
+    line-style="dotted"
+/>
 
 <div grow-1><!-- Placeholder--></div>
 

--- a/slides.md
+++ b/slides.md
@@ -487,6 +487,92 @@ If no snap target or absolute position is specified, the arrow will automaticall
 
 ---
 
+# Line style
+
+<div grid="~ cols-3 gap-4" mt-6 h-100>
+
+<div bg-gray:10 p-4 border="~ gray/50 rounded-lg" flex="~ col">
+
+### Solid
+
+<FancyArrow x1="100" y1="180" x2="200" y2="280" width="2" line-style="solid" />
+<FancyArrow x1="140" y1="180" x2="240" y2="280" width="4" line-style="solid" />
+<FancyArrow x1="180" y1="180" x2="280" y2="280" width="6" line-style="solid" />
+
+<div grow-1><!-- Placeholder--></div>
+
+```html {2,5,8}
+<FancyArrow x1="100" y1="180" x2="200" y2="280" width="2"
+    line-style="solid"
+/>
+<FancyArrow x1="140" y1="180" x2="240" y2="280" width="4"
+    line-style="solid"
+/>
+<FancyArrow x1="180" y1="180" x2="280" y2="280" width="6"
+    line-style="solid"
+/>
+```
+
+</div>
+
+<div bg-gray:10 p-4 border="~ gray/50 rounded-lg" flex="~ col">
+
+### Dashed
+
+<FancyArrow x1="400" y1="180" x2="500" y2="280" width="2" line-style="dashed" />
+<FancyArrow x1="440" y1="180" x2="540" y2="280" width="4" line-style="dashed" />
+<FancyArrow x1="480" y1="180" x2="580" y2="280" width="6" line-style="dashed" />
+
+<div grow-1><!-- Placeholder--></div>
+
+```html {2,5,8}
+<FancyArrow x1="400" y1="180" x2="500" y2="280" width="2"
+    line-style="dashed"
+/>
+<FancyArrow x1="440" y1="180" x2="540" y2="280" width="4"
+    line-style="dashed"
+/>
+<FancyArrow x1="480" y1="180" x2="580" y2="280" width="6"
+    line-style="dashed"
+/>
+```
+
+</div>
+
+<div bg-gray:10 p-4 border="~ gray/50 rounded-lg" flex="~ col">
+
+### Dotted
+
+<FancyArrow x1="700" y1="180" x2="800" y2="280" width="2" line-style="dotted" />
+<FancyArrow x1="740" y1="180" x2="840" y2="280" width="4" line-style="dotted" />
+<FancyArrow x1="780" y1="180" x2="880" y2="280" width="6" line-style="dotted" />
+
+<div grow-1><!-- Placeholder--></div>
+
+```html {2,5,8}
+<FancyArrow x1="700" y1="180" x2="800" y2="280" width="2"
+    line-style="dotted"
+/>
+<FancyArrow x1="740" y1="180" x2="840" y2="280" width="4"
+    line-style="dotted"
+/>
+<FancyArrow x1="780" y1="180" x2="880" y2="280" width="6"
+    line-style="dotted"
+/>
+```
+
+</div>
+
+</div>
+
+<div text-sm op-75 mt-2>
+
+The dash pattern scales with `width`, and applies to the line only so that the arrow head stays readable.
+
+</div>
+
+---
+
 # Rough.js options
 
 <div grid="~ cols-3 gap-4" mt-6 h-100>


### PR DESCRIPTION
Arrows could only be drawn as solid lines, so there was no way to distinguish a tentative or secondary relation from a primary one on a slide.

`line-style` accepts `solid` (the default), `dashed`, or `dotted`, and sets a dash pattern on the line. The pattern scales with `width` and is not applied to the arrow head, which would break up at typical head sizes.

The stroke-drawing animation needed work to survive this: it reveals the line by pinning `stroke-dasharray` to the path length and sweeping `stroke-dashoffset`, so it needs `stroke-dasharray` for itself and a dashed line would have lost its pattern the moment it animated. While animating, the line is now wrapped in a masked group and the animation runs on white copies of it inside the `<mask>`, revealing the dashed line as they are drawn.

Closes #376


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added solid, dashed, and dotted line styles for `FancyArrow`.
  - Dash patterns scale with line width, while arrowheads remain solid for readability.
  - Dashed and dotted styles continue to support line animations.
  - Added examples demonstrating the available styles and configurations.

- **Documentation**
  - Updated the README and slides with usage guidance and visual examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->