### PR TITLE
fix(ci): List the root package in `pnpm-workspace.yaml` so changesets can find it

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,7 @@
-packages: []
+# The root package is the published one. It has to be listed here, or changesets
+# sees a workspace with no packages and `changeset version` fails on any changeset.
+packages:
+  - "."
 allowBuilds:
   esbuild: true
 # pnpm 11 renamed `allowBuilds` from `onlyBuiltDependencies` and ignores the old key

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
-# The root package is the published one. It has to be listed here, or changesets
-# sees a workspace with no packages and `changeset version` fails on any changeset.
+# pnpm refuses to read this file without a `packages` key, and an empty list would
+# declare a workspace holding no packages, leaving changesets unable to resolve the
+# package any changeset names. The root package is the published one, so list it.
 packages:
   - "."
 allowBuilds:


### PR DESCRIPTION
The `release` job on `main` fails at `changeset version` with "Found changeset `fair-pugs-hear` for package `slidev-addon-fancy-arrow` which is not in the workspace". #386 added `packages: []` to `pnpm-workspace.yaml` because pnpm refuses to read the file without that key, but an empty list declares a workspace containing no packages, so `@manypkg/get-packages`, which changesets uses to enumerate the workspace, returns nothing and no changeset can resolve its package.

Listing the root package satisfies both sides: pnpm still finds the key it requires, and changesets finds `slidev-addon-fancy-arrow` again. The lockfile needs no change, since its only importer was already `.`.

No check on this PR exercises the fixed path, since the `release` job only runs on pushes to the default branch. `pnpm exec changeset status` names `slidev-addon-fancy-arrow` as the package to bump, which is what fails on `main` today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)