### PR TITLE
fix: Regenerate the arrow when a styling prop changes

### DIFF
--- a/.changeset/lucky-donkeys-smile.md
+++ b/.changeset/lucky-donkeys-smile.md
@@ -1,0 +1,5 @@
+---
+"slidev-addon-fancy-arrow": patch
+---
+
+Honor an explicit `0` for `head-size` and `roughness`. Both were read with a truthiness check, so a bound `:roughness="0"` fell back to the Rough.js default instead of drawing a straight line.

--- a/.changeset/tidy-moons-repeat.md
+++ b/.changeset/tidy-moons-repeat.md
@@ -1,0 +1,5 @@
+---
+"slidev-addon-fancy-arrow": patch
+---
+
+Regenerate the arrow when `width`, `arc`, `head-type`, `head-size`, `roughness`, `seed`, or `two-way` changes. These props were read once while the component was set up, so a bound value such as `:width="big ? 10 : 2"` kept rendering whatever it resolved to first.

--- a/components/FancyArrow.vue
+++ b/components/FancyArrow.vue
@@ -177,13 +177,13 @@ const animationEnabled = computed(() => {
 const { arrowSvg, textPosition } = useRoughArrow({
   point1: tailAbsPos,
   point2: headAbsPos,
-  width: Number(props.width ?? 2),
-  twoWay: props.twoWay ?? false,
-  centerPositionParam: Number(props.arc ?? 0),
-  headType: props.headType ?? "line",
-  headSize: props.headSize ? Number(props.headSize) : null,
-  roughness: props.roughness ? Number(props.roughness) : undefined,
-  seed: props.seed ? Number(props.seed) : undefined,
+  width: () => Number(props.width ?? 2),
+  twoWay: () => props.twoWay ?? false,
+  centerPositionParam: () => Number(props.arc ?? 0),
+  headType: () => props.headType ?? "line",
+  headSize: () => (props.headSize ? Number(props.headSize) : null),
+  roughness: () => (props.roughness ? Number(props.roughness) : undefined),
+  seed: () => (props.seed ? Number(props.seed) : undefined),
   animation: computed(() =>
     animationEnabled.value
       ? {

--- a/components/FancyArrow.vue
+++ b/components/FancyArrow.vue
@@ -181,9 +181,10 @@ const { arrowSvg, textPosition } = useRoughArrow({
   twoWay: () => props.twoWay ?? false,
   centerPositionParam: () => Number(props.arc ?? 0),
   headType: () => props.headType ?? "line",
-  headSize: () => (props.headSize ? Number(props.headSize) : null),
-  roughness: () => (props.roughness ? Number(props.roughness) : undefined),
-  seed: () => (props.seed ? Number(props.seed) : undefined),
+  headSize: () => (props.headSize != null ? Number(props.headSize) : null),
+  roughness: () =>
+    props.roughness != null ? Number(props.roughness) : undefined,
+  seed: () => (props.seed != null ? Number(props.seed) : undefined),
   animation: computed(() =>
     animationEnabled.value
       ? {

--- a/components/use-rough-arrow.ts
+++ b/components/use-rough-arrow.ts
@@ -1,4 +1,4 @@
-import { computed, type Ref } from "vue";
+import { computed, toValue, type MaybeRefOrGetter, type Ref } from "vue";
 import roughjs from "roughjs";
 import { splitPath } from "./split-path";
 
@@ -56,13 +56,13 @@ export interface AbsolutePosition {
 export function useRoughArrow(props: {
   point1: Ref<AbsolutePosition | undefined>;
   point2: Ref<AbsolutePosition | undefined>;
-  width: number;
-  headType: "line" | "polygon";
-  headSize: number | null;
-  roughness?: number;
-  seed?: number;
-  twoWay: boolean;
-  centerPositionParam: number;
+  width: MaybeRefOrGetter<number>;
+  headType: MaybeRefOrGetter<"line" | "polygon">;
+  headSize: MaybeRefOrGetter<number | null>;
+  roughness?: MaybeRefOrGetter<number | undefined>;
+  seed?: MaybeRefOrGetter<number | undefined>;
+  twoWay: MaybeRefOrGetter<boolean>;
+  centerPositionParam: MaybeRefOrGetter<number>;
   animation: Ref<
     | {
         duration?: number;
@@ -76,22 +76,22 @@ export function useRoughArrow(props: {
   const {
     point1: point1Ref,
     point2: point2Ref,
-    width,
-    headType,
-    headSize,
-    roughness,
-    seed,
-    twoWay,
-    centerPositionParam,
     animation,
     strokeAnimationClass,
     fillAnimationClass,
   } = props;
-  const baseOptions = {
-    // We don't support the `bowing` param because it's not so effective for arc.
-    ...(roughness !== undefined && { roughness }),
-    ...(seed !== undefined && { seed }),
-  } as const;
+
+  // The styling props are read through toValue() inside the computeds below rather
+  // than unwrapped once here, so that updating one regenerates the SVG.
+  function getBaseOptions() {
+    const roughness = toValue(props.roughness);
+    const seed = toValue(props.seed);
+    return {
+      // We don't support the `bowing` param because it's not so effective for arc.
+      ...(roughness !== undefined && { roughness }),
+      ...(seed !== undefined && { seed }),
+    };
+  }
   const roughSvg = roughjs.svg(
     document.createElementNS("http://www.w3.org/2000/svg", "svg"),
   );
@@ -108,8 +108,11 @@ export function useRoughArrow(props: {
       return null;
     }
 
+    const width = toValue(props.width);
+    const centerPositionParam = toValue(props.centerPositionParam);
+
     const lineOptions = {
-      ...baseOptions,
+      ...getBaseOptions(),
       stroke: "currentColor",
       strokeWidth: width,
     };
@@ -226,6 +229,7 @@ export function useRoughArrow(props: {
       return 0;
     }
 
+    const headSize = toValue(props.headSize);
     if (headSize != null) {
       return headSize;
     }
@@ -244,9 +248,14 @@ export function useRoughArrow(props: {
       return null;
     }
 
+    const width = toValue(props.width);
+    const headType = toValue(props.headType);
+    const twoWay = toValue(props.twoWay);
+    const centerPositionParam = toValue(props.centerPositionParam);
+
     const lineLength = getArrowHeadLineLength();
     const arrowHeadOptions = {
-      ...baseOptions,
+      ...getBaseOptions(),
       stroke: "currentColor",
       strokeWidth: width,
       fill: "currentColor",

--- a/components/use-rough-arrow.ts
+++ b/components/use-rough-arrow.ts
@@ -81,8 +81,8 @@ export function useRoughArrow(props: {
     fillAnimationClass,
   } = props;
 
-  // The styling props are read through toValue() inside the computeds below rather
-  // than unwrapped once here, so that updating one regenerates the SVG.
+  // Each computed reads only the props it uses. A single shared read would make a
+  // head-size change re-run arcData, re-roughening the line with a fresh random seed.
   function getBaseOptions() {
     const roughness = toValue(props.roughness);
     const seed = toValue(props.seed);


### PR DESCRIPTION
`width`, `arc`, `head-type`, `head-size`, `roughness`, `seed`, and `two-way` were read once while the component was set up, so binding one to reactive state did nothing after the first render. `:width="big ? 10 : 2"` kept drawing at the width it resolved to when the arrow first appeared, even as the rest of the component re-rendered around it. `color` was unaffected, since it is bound in the template rather than passed through the rendering composable.

`useRoughArrow` now takes these props as `MaybeRefOrGetter` and reads them with `toValue()` inside the computeds that build the SVG, and `FancyArrow` passes them as getters. Each computed reads only the props it uses, so changing `head-size` rebuilds the arrow heads while leaving the line's generated path untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Arrows now regenerate automatically when relevant configuration properties change.
  * Updates to arrow appearance and behavior settings are reflected without retaining outdated initial values.
  * Explicit `0` values for head size and roughness are now honored instead of being replaced by defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->