### PR TITLE
fix: Keep a drawn arrow from drawing itself again when it re-renders

### DIFF
--- a/.changeset/perfect-otters-relax.md
+++ b/.changeset/perfect-otters-relax.md
@@ -2,4 +2,4 @@
 "slidev-addon-fancy-arrow": patch
 ---
 
-Keep an arrow from drawing itself again when a snapped element moves after the drawing animation has finished
+Keep an arrow that has finished drawing from drawing itself again when it is re-rendered, as it is whenever its endpoints move

--- a/.changeset/perfect-otters-relax.md
+++ b/.changeset/perfect-otters-relax.md
@@ -1,0 +1,5 @@
+---
+"slidev-addon-fancy-arrow": patch
+---
+
+Keep an arrow from drawing itself again when a snapped element moves after the drawing animation has finished

--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ The dash pattern scales with `width`, and applies to the line only so that the a
 
 ### Animation
 
+An arrow draws itself once each time it appears. While it stays on screen, an arrow snapped to an element that moves follows it without drawing itself again.
+
 #### Animation properties
 
 ```html

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The dash pattern scales with `width`, and applies to the line only so that the a
 
 ### Animation
 
-An arrow draws itself once each time it appears. While it stays on screen, an arrow whose endpoints move follows them without drawing itself again.
+An arrow draws itself once each time it appears. Once it has finished drawing, an arrow whose endpoints move follows them without drawing itself again for as long as it stays on screen.
 
 #### Animation properties
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The dash pattern scales with `width`, and applies to the line only so that the a
 
 ### Animation
 
-An arrow draws itself once each time it appears. While it stays on screen, an arrow snapped to an element that moves follows it without drawing itself again.
+An arrow draws itself once each time it appears. While it stays on screen, an arrow whose endpoints move follows them without drawing itself again.
 
 #### Animation properties
 

--- a/components/FancyArrow.vue
+++ b/components/FancyArrow.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, useSlots } from "vue";
+import { ref, computed, useSlots, onBeforeUpdate, onUpdated } from "vue";
 import {
   compileArrowEndpointProps,
   SnapTargetQuery,
@@ -201,6 +201,30 @@ const { arrowSvg, textPosition } = useRoughArrow({
   ),
   strokeAnimationClass: "animated-rough-arrow-stroke",
   fillAnimationClass: "animated-rough-arrow-fill",
+});
+
+function getArrowAnimations(): Animation[] {
+  return svgContainer.value?.getAnimations({ subtree: true }) ?? [];
+}
+
+// Re-rendering the arrow, which an endpoint moving is enough to do, hands the browser
+// fresh elements that start the drawing animation over from the beginning. An arrow
+// that had already finished drawing is jumped to the end of the new animation instead,
+// so that it just follows the element it is snapped to.
+// The animation stays in place and armed, so the arrow draws itself again whenever a
+// `v-click` reveal or a slide transition replays it.
+let arrowWasDrawn = false;
+onBeforeUpdate(() => {
+  const animations = getArrowAnimations();
+  arrowWasDrawn =
+    animations.length > 0 &&
+    animations.every((animation) => animation.playState === "finished");
+});
+onUpdated(() => {
+  if (!arrowWasDrawn) {
+    return;
+  }
+  getArrowAnimations().forEach((animation) => animation.finish());
 });
 </script>
 

--- a/components/FancyArrow.vue
+++ b/components/FancyArrow.vue
@@ -207,12 +207,12 @@ function getArrowAnimations(): Animation[] {
   return svgContainer.value?.getAnimations({ subtree: true }) ?? [];
 }
 
-// Re-rendering the arrow, which an endpoint moving is enough to do, hands the browser
-// fresh elements that start the drawing animation over from the beginning. An arrow
-// that had already finished drawing is jumped to the end of the new animation instead,
-// so that it just follows the element it is snapped to.
-// The animation stays in place and armed, so the arrow draws itself again whenever a
-// `v-click` reveal or a slide transition replays it.
+// Every re-render replaces the arrow's elements,
+// and the new ones start the drawing animation from the beginning.
+// So once the arrow has finished drawing, we skip the new animation to its end,
+// and the arrow simply appears at its new position.
+// The animation itself is left as it is,
+// so a `v-click` reveal or a slide transition still replays the drawing.
 let arrowWasDrawn = false;
 onBeforeUpdate(() => {
   const animations = getArrowAnimations();

--- a/slides.md
+++ b/slides.md
@@ -1025,4 +1025,4 @@ clicks: 4
 <div absolute left="50%" top="50%" translate-x="-50%" translate-y="-50%" data-id="center-anchor"></div>
 <div absolute right-10 top="50%" translate-x="-50%" translate-y="-50%" data-id="right-anchor">Anchor</div>
 
-<FancyArrow q1="[data-id=center-anchor]" :x2="$clicks % 2 === 0 ? 100 : 900" :y2="$clicks / 2 < 1 ? 100 : 500" :q2="$clicks > 3 ? '[data-id=right-anchor]' : undefined" static />
+<FancyArrow q1="[data-id=center-anchor]" :x2="$clicks % 2 === 0 ? 100 : 900" :y2="$clicks / 2 < 1 ? 100 : 500" :q2="$clicks > 3 ? '[data-id=right-anchor]' : undefined" />


### PR DESCRIPTION
An arrow re-renders whenever an endpoint moves or a styling prop changes, and the fresh elements hand the browser a drawing animation that starts over from the beginning, so an arrow that has already drawn itself draws again every time it settles somewhere new.

An arrow that has already finished drawing is now jumped to the end of the new animation, so that it just follows the position it is rendered at. The animation itself is left in place and armed, so a `v-click` reveal or a slide transition still replays the drawing, and the `static` prop is no longer needed on the "Demo: dynamic positions" arrow.

Closes #288

This behavior is not covered by the unit tests: `happy-dom` implements no CSS animations, so `getAnimations()` finds nothing there. `pnpm dev` exercises it on the "Demo: arrows snapped to animated elements" and "Demo: dynamic positions" slides, the latter of which no longer carries `static`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Completed arrow animations no longer replay when endpoints move or the arrow is re-rendered.
  - Arrows continue following moving endpoints while remaining visually complete.

- **Documentation**
  - Clarified that arrows animate once on appearance, then track endpoint movement without redrawing.

- **Examples**
  - Updated the dynamic-positions example to demonstrate animated arrows by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->