### PR TITLE
chore: Keep a failed Chrome install from blocking cloud sessions

### DIFF
--- a/.claude/cloud-setup.sh
+++ b/.claude/cloud-setup.sh
@@ -6,23 +6,28 @@
 # Project dependencies are installed by the SessionStart hook in settings.json
 # instead, because that one runs in the repository directory.
 #
-# A non-zero exit stops the session from starting, so nothing here is fatal. A
-# session without Chrome still works for everything but screenshots, and
-# scripts/screenshot.js says what is missing.
+# A non-zero exit stops the session from being created, so nothing here is
+# fatal. Without Chrome a session runs everything except screenshots.
 set -uxo pipefail
 
-if ! command -v google-chrome > /dev/null && ! command -v chromium > /dev/null; then
-  # The download comes from storage.googleapis.com, which the Trusted network
-  # access level allows, but resolving `stable` to a version reads
-  # googlechromelabs.github.io, which it does not. The environment needs that
-  # host in its allowed domains. The installer prints "chrome@<version> <path>".
-  chrome="$(npx --yes @puppeteer/browsers install chrome@stable --path /opt/chrome | tail -1 | cut -d " " -f 2-)"
+# `@puppeteer/browsers` looks a channel name up through googlechromelabs.github.io,
+# which the Trusted network access level does not allow, while it takes a
+# four-part build id as given and downloads it from storage.googleapis.com, which
+# Trusted does allow. Bumping this is manual; any Chrome for Testing build works.
+CHROME_VERSION=152.0.7977.64
 
-  # A session does not inherit this script's environment, so CHROME_PATH cannot
-  # be handed over that way. scripts/screenshot.js looks for this symlink.
-  if [ -n "$chrome" ] && [ -x "$chrome" ]; then
-    ln -sf "$chrome" /usr/local/bin/google-chrome
+chrome="$(command -v google-chrome || command -v chromium || command -v chromium-browser)"
+if [ -z "$chrome" ]; then
+  # The installer prints "chrome@<version> <path>".
+  if ! chrome="$(npx --yes @puppeteer/browsers install "chrome@$CHROME_VERSION" --path /opt/chrome | tail -1 | cut -d " " -f 2-)"; then
+    echo "Chrome install failed, so scripts/screenshot.js has nothing to drive." >&2
   fi
+fi
+
+# A session does not inherit this script's environment, so CHROME_PATH cannot be
+# handed over that way. scripts/screenshot.js looks for this symlink.
+if [ -x "$chrome" ] && [ "$chrome" != /usr/local/bin/google-chrome ]; then
+  ln -sf "$chrome" /usr/local/bin/google-chrome
 fi
 
 exit 0

--- a/.claude/cloud-setup.sh
+++ b/.claude/cloud-setup.sh
@@ -5,12 +5,24 @@
 #
 # Project dependencies are installed by the SessionStart hook in settings.json
 # instead, because that one runs in the repository directory.
-set -euxo pipefail
+#
+# A non-zero exit stops the session from starting, so nothing here is fatal. A
+# session without Chrome still works for everything but screenshots, and
+# scripts/screenshot.js says what is missing.
+set -uxo pipefail
 
-# Chrome for Testing comes from storage.googleapis.com, which the Trusted network
-# access level already allows. The installer prints "chrome@<version> <path>".
-chrome="$(npx --yes @puppeteer/browsers install chrome@stable --path /opt/chrome | tail -1 | cut -d " " -f 2-)"
+if ! command -v google-chrome > /dev/null && ! command -v chromium > /dev/null; then
+  # The download comes from storage.googleapis.com, which the Trusted network
+  # access level allows, but resolving `stable` to a version reads
+  # googlechromelabs.github.io, which it does not. The environment needs that
+  # host in its allowed domains. The installer prints "chrome@<version> <path>".
+  chrome="$(npx --yes @puppeteer/browsers install chrome@stable --path /opt/chrome | tail -1 | cut -d " " -f 2-)"
 
-# A session does not inherit this script's environment, so CHROME_PATH cannot be
-# handed over that way. scripts/screenshot.js looks for this symlink instead.
-ln -sf "$chrome" /usr/local/bin/google-chrome
+  # A session does not inherit this script's environment, so CHROME_PATH cannot
+  # be handed over that way. scripts/screenshot.js looks for this symlink.
+  if [ -n "$chrome" ] && [ -x "$chrome" ]; then
+    ln -sf "$chrome" /usr/local/bin/google-chrome
+  fi
+fi
+
+exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,4 +88,4 @@ node scripts/screenshot.js 1 --clicks 3
 
 `pnpm dev` is the wrong command here because it passes `--open` and a VM has no browser to open. The script waits for the drawing animations to finish, so a capture shows an arrow in its final state.
 
-The environment at claude.ai/code has to provide two things. Its setup script installs Chrome, and `.claude/cloud-setup.sh` holds the copy to paste in. Its network access level has to allow `cdn.playwright.dev` for `pnpm export` to work there; the Trusted level covers everything else the project needs.
+The environment at claude.ai/code has to provide two things. Its setup script installs Chrome, and `.claude/cloud-setup.sh` holds the copy to paste in. Its network access has to be Custom with the default list included, plus `googlechromelabs.github.io`, where the installer looks up the current Chrome version, and `cdn.playwright.dev` if `pnpm export` should work there too.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,4 +88,4 @@ node scripts/screenshot.js 1 --clicks 3
 
 `pnpm dev` is the wrong command here because it passes `--open` and a VM has no browser to open. The script waits for the drawing animations to finish, so a capture shows an arrow in its final state.
 
-The environment at claude.ai/code has to provide two things. Its setup script installs Chrome, and `.claude/cloud-setup.sh` holds the copy to paste in. Its network access has to be Custom with the default list included, plus `googlechromelabs.github.io`, where the installer looks up the current Chrome version, and `cdn.playwright.dev` if `pnpm export` should work there too.
+The environment at claude.ai/code needs the setup script in `.claude/cloud-setup.sh` pasted into its Setup script field, which installs Chrome when the image ships none. Its network access can stay on Trusted, since the script pins a Chrome for Testing build rather than looking a channel name up on a host Trusted blocks. Add `cdn.playwright.dev` to a Custom allowlist if `pnpm export` should work there too.


### PR DESCRIPTION
The setup script added by #414 fails in a cloud session with `Error: Got status code 403`, and because a non-zero exit from a setup script stops the session from being created, a missing screenshot tool takes the whole environment down with it.

`@puppeteer/browsers` resolves `chrome@stable` by reading `googlechromelabs.github.io`, a host the Trusted network access level does not allow. The binary itself comes from `storage.googleapis.com`, which Trusted does allow, and a four-part build id is passed through without any lookup.

So the script now pins a Chrome for Testing build, which keeps the whole install inside Trusted and leaves the environment's network settings alone. It also reuses `google-chrome` or `chromium` when the image already ships one, and symlinks whichever binary it ends up with to the path `scripts/screenshot.js` looks for. Setup is best effort from here: `set -e` is gone and the script ends in `exit 0`, so a session always starts, and a failed install says so in the setup log rather than passing silently.

Bumping the pin is manual. Any published Chrome for Testing build works, and `CLAUDE.md` records why the version is written out rather than resolved.
