### PR TITLE
Fix screenshot script hanging and capturing unrendered slides

### DIFF
--- a/scripts/screenshot.js
+++ b/scripts/screenshot.js
@@ -58,9 +58,11 @@ const browser = await puppeteer.launch({
   args: ["--no-sandbox"],
 });
 // Vite reloads the page when it meets a dependency it has not optimized yet, which
-// is routine on a cold dev server and destroys whatever we were waiting on.
+// is routine on a cold dev server and destroys whatever we were waiting on. The page
+// itself survives the reload, so retrying on it is enough. A closed target is not in
+// this set on purpose: it means the browser is gone, which no retry can recover.
 const isNavigationError = (error) =>
-  /Execution context was destroyed|Execution context is not available|frame was detached|Target closed/.test(
+  /Execution context was destroyed|Execution context is not available|frame was detached/.test(
     error.message,
   );
 

--- a/scripts/screenshot.js
+++ b/scripts/screenshot.js
@@ -11,6 +11,8 @@ import { parseArgs } from "node:util";
 import puppeteer from "puppeteer-core";
 
 const VIEWPORT = { width: 1280, height: 720, deviceScaleFactor: 2 };
+const PAGE_READY_TIMEOUT = 60000;
+const RELOAD_RETRIES = 3;
 const ANIMATION_START_TIMEOUT = 2000;
 const ANIMATION_END_TIMEOUT = 5000;
 
@@ -21,6 +23,8 @@ const CHROME_CANDIDATES = [
   "/usr/bin/google-chrome",
   "/usr/bin/chromium",
   "/usr/bin/chromium-browser",
+  // Playwright's browsers, which some cloud images ship instead of a system Chrome.
+  "/opt/pw-browsers/chromium",
 ];
 
 const { values, positionals } = parseArgs({
@@ -53,21 +57,40 @@ const browser = await puppeteer.launch({
   executablePath,
   args: ["--no-sandbox"],
 });
-try {
-  const page = await browser.newPage();
-  await page.setViewport(VIEWPORT);
-  const query = values.clicks ? `?clicks=${values.clicks}` : "";
-  await page.goto(`${values.url}/${slide}${query}`, {
-    waitUntil: "networkidle0",
-  });
-  // An arrow animates itself into place once its endpoints resolve, which happens
-  // after the load event. Wait for the first animation to exist, otherwise the
-  // wait below has nothing to wait for and the capture catches an empty slide.
+// Vite reloads the page when it meets a dependency it has not optimized yet, which
+// is routine on a cold dev server and destroys whatever we were waiting on.
+const isNavigationError = (error) =>
+  /Execution context was destroyed|Execution context is not available|frame was detached|Target closed/.test(
+    error.message,
+  );
+
+// The load event only means the entry module arrived. The slide mounts later, and on
+// a cold dev server it sits behind a "Loading slide..." placeholder while Vite
+// compiles, which can take tens of seconds. Without this wait the capture is a blank
+// page or that placeholder. Neighbouring slides are in the DOM too, so this looks at
+// the requested one rather than whichever `.slidev-page` comes first.
+const waitForSlide = (page) =>
+  page.waitForFunction(
+    (slideNumber) => {
+      const el = document.querySelector(`.slidev-page-${slideNumber}`);
+      if (!el || /Loading slide/.test(el.innerText)) return false;
+      return el.innerText.trim() !== "" || el.querySelector("img, svg, video");
+    },
+    { timeout: PAGE_READY_TIMEOUT, polling: 100 },
+    slide,
+  );
+
+// An arrow animates itself into place once its endpoints resolve, which happens after
+// the load event. Wait for the first animation to exist, otherwise the wait below has
+// nothing to wait for and the capture catches an arrow that has not been drawn yet.
+const waitForAnimations = async (page) => {
   await page
     .waitForFunction(() => document.getAnimations().length > 0, {
       timeout: ANIMATION_START_TIMEOUT,
     })
-    .catch(() => {});
+    .catch((error) => {
+      if (isNavigationError(error)) throw error;
+    });
   await page.evaluate(async (timeout) => {
     await Promise.race([
       Promise.all(
@@ -76,6 +99,26 @@ try {
       new Promise((resolve) => setTimeout(resolve, timeout)),
     ]);
   }, ANIMATION_END_TIMEOUT);
+};
+
+try {
+  const page = await browser.newPage();
+  await page.setViewport(VIEWPORT);
+  const query = values.clicks ? `?clicks=${values.clicks}` : "";
+  // Not `networkidle0`: Slidev keeps a `/@server-reactive/` connection open for the
+  // life of the page, so the network never goes idle and the navigation times out.
+  await page.goto(`${values.url}/${slide}${query}`, {
+    waitUntil: "load",
+  });
+  for (let attempt = 0; ; attempt++) {
+    try {
+      await waitForSlide(page);
+      await waitForAnimations(page);
+      break;
+    } catch (error) {
+      if (attempt >= RELOAD_RETRIES || !isNavigationError(error)) throw error;
+    }
+  }
   await page.screenshot({ path: out });
 } finally {
   await browser.close();


### PR DESCRIPTION
`scripts/screenshot.js` could not capture a slide in a cloud session. Every run died in navigation, and the fixes for that uncovered two more problems underneath.

## Problems

**1. `networkidle0` never settles.** Slidev keeps a `/@server-reactive/` connection open for the life of the page, so the network is never idle for 500ms and `page.goto` timed out after 30s on every run.

**2. `load` fires long before the slide renders.** Waiting for `load` instead is not enough on its own: at that point the body is ~332 characters, and on a cold dev server the slide sits behind a "Loading slide..." placeholder until Vite finishes compiling. The capture came out blank, or as a picture of the spinner. Waiting for `.slidev-page` alone does not fix it either — neighbouring slides are in the DOM too, so it can match a slide other than the requested one.

**3. Vite full-reloads the page on first dependency optimization.** That is routine on a cold dev server, and it destroys the execution context the animation waits run in, failing the whole capture with `Execution context was destroyed`.

Separately, `CHROME_CANDIDATES` listed no path that exists on images shipping Playwright's browsers rather than a system Chrome, so the script exited early unless `CHROME_PATH` was set by hand.

## Changes

- Navigate with `waitUntil: "load"` rather than `networkidle0`.
- After load, wait for the *requested* slide — `.slidev-page-` plus the slide number — to hold real content: no "Loading slide..." text, and either non-empty text or an `img`/`svg`/`video`.
- Retry the readiness and animation waits when a Vite reload interrupts them, up to `RELOAD_RETRIES`.
- Add `/opt/pw-browsers/chromium` to `CHROME_CANDIDATES`.

## Verification

From a fully cold state each time (dev server killed, `node_modules/.vite` cleared):

- `node scripts/screenshot.js 1` — 34s, renders the title slide with all four arrows in their final drawn state. Warm reruns take ~10s.
- `node scripts/screenshot.js 4 --clicks 2` — renders the click-stage slide with all three arrows.
- Confirmed the pre-fix failure modes reproduce on the old code: navigation timeout, then a blank capture, then `Execution context was destroyed`.
- `pnpm lint` clean, `pnpm test` 86/86 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved screenshot generation reliability by waiting for slides to finish loading.
  * Added automatic recovery when development-server reloads interrupt navigation.
  * Expanded browser compatibility by detecting Playwright’s bundled Chromium installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->