### PR TITLE
Make a cloud session work without environment setup

### DIFF
--- a/.claude/cloud-setup.sh
+++ b/.claude/cloud-setup.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 # Setup script for Claude Code cloud environments, kept here so that it is
-# versioned and reviewable. Paste it into the Setup script field of the
-# environment at claude.ai/code. Nothing in the repository runs it.
+# versioned and reviewable. Nothing in the repository runs it: paste it into the
+# Setup script field of the environment at claude.ai/code.
+#
+# It is a fallback, not a requirement. Those images ship Playwright's Chromium at
+# /opt/pw-browsers/chromium, which scripts/screenshot.js looks for by itself, so
+# an environment only needs this script when its image ships no browser at all.
 #
 # Project dependencies are installed by the SessionStart hook in settings.json
 # instead, because that one runs in the repository directory.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,11 +81,13 @@ When modifying the `<FancyArrow>` component interface (props, slots, usage patte
 A cloud session has no browser, so the only way to look at a slide is to render it to a PNG and read the image back.
 
 ```bash
-pnpm exec slidev --port 3030 &
+pnpm dev:headless --port 3030 &
 node scripts/screenshot.js 1           # writes screenshots/slide-1.png
 node scripts/screenshot.js 1 --clicks 3
 ```
 
-`pnpm dev` is the wrong command here because it passes `--open` and a VM has no browser to open. The script waits for the drawing animations to finish, so a capture shows an arrow in its final state.
+`pnpm dev` is the wrong command here because it passes `--open` and a VM has no browser to open, which is what `dev:headless` exists for. The screenshot script waits for the drawing animations to finish, so a capture shows an arrow in its final state.
 
-The environment at claude.ai/code needs the setup script in `.claude/cloud-setup.sh` pasted into its Setup script field, which installs Chrome when the image ships none. Its network access can stay on Trusted, since the script pins a Chrome for Testing build rather than looking a channel name up on a host Trusted blocks. Add `cdn.playwright.dev` to a Custom allowlist if `pnpm export` should work there too.
+`scripts/screenshot.js` finds a browser on its own. The images at claude.ai/code ship Playwright's Chromium at `/opt/pw-browsers/chromium`, which is one of the paths it looks in, so a session there captures slides with no environment setup at all.
+
+The setup script in `.claude/cloud-setup.sh` is a fallback for an image that ships no browser: paste it into the environment's Setup script field, and it installs Chrome. Nothing in the repository runs it. Network access can stay on Trusted either way, since the script pins a Chrome for Testing build rather than looking a channel name up on a host Trusted blocks. Add `cdn.playwright.dev` to a Custom allowlist if `pnpm export` should work there too, which also needs `playwright-chromium`, a package this repository does not depend on.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "build": "slidev build",
     "dev": "slidev --open",
+    "dev:headless": "slidev",
     "export": "slidev export",
     "lint": "oxlint",
     "format": "oxfmt",


### PR DESCRIPTION
Follow-up to #424. Two pieces of friction left in running this project from a session at claude.ai/code.

## The setup script is no longer needed there

`CLAUDE.md` said an environment "needs" `.claude/cloud-setup.sh` pasted into its Setup script field. That is a manual, per-environment step, and forgetting it silently costs the session its screenshots.

It buys nothing on those images any more. They ship Playwright's Chromium at `/opt/pw-browsers/chromium`, which #424 added to the paths `scripts/screenshot.js` searches. The script finds a browser with no environment setup at all.

Verified rather than assumed: with `/usr/local/bin/google-chrome` (the symlink `cloud-setup.sh` creates) moved aside, leaving `/opt/pw-browsers/chromium` as the only candidate that exists, a cold `node scripts/screenshot.js 1` — dev server killed, `node_modules/.vite` cleared — captured the title slide correctly in 39s. The symlink was restored afterwards.

So both `CLAUDE.md` and the script's own header now describe it as a fallback for an image that ships no browser.

## `pnpm dev` is still wrong in a session

It passes `--open`, and a VM has no browser to open, so the docs had to tell readers which command *not* to run and hand them a raw `pnpm exec slidev` line instead. `dev:headless` makes the documented path a real script. `pnpm dev` keeps `--open` for local use.

## Changes

- `package.json`: add `"dev:headless": "slidev"`.
- `CLAUDE.md`: use `pnpm dev:headless --port 3030`; state that the screenshot script finds a browser by itself; demote the setup script to a fallback.
- `.claude/cloud-setup.sh`: same demotion in its header comment, so the file does not contradict the docs.
- Also note that `pnpm export` needs `playwright-chromium`, which this repository does not depend on — previously the docs mentioned only the `cdn.playwright.dev` allowlist entry, which alone is not enough to make that command work.

No change to `scripts/screenshot.js`.

## Verification

- Cold capture on Playwright's Chromium with the setup script's Chrome hidden, as above.
- `pnpm dev:headless --port 3030` serves without opening a browser; `node scripts/screenshot.js 2` against it captures correctly.
- `pnpm lint` clean, `pnpm test` 86/86, `pnpm build` succeeds.
- The `SessionStart` hook (`pnpm install --frozen-lockfile`) exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ggayx1Rt8451o5xV2cTdpa)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a headless development command that runs without attempting to open a browser, improving compatibility with browserless environments.

- **Documentation**
  - Clarified cloud session setup, browser availability, screenshot behavior, and when optional browser setup is required.
  - Updated network access guidance for Playwright browser downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->