### PR TITLE
Document how to export a PDF from a cloud session

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,4 +90,18 @@ node scripts/screenshot.js 1 --clicks 3
 
 `scripts/screenshot.js` finds a browser on its own. The images at claude.ai/code ship Playwright's Chromium at `/opt/pw-browsers/chromium`, which is one of the paths it looks in, so a session there captures slides with no environment setup at all.
 
-The setup script in `.claude/cloud-setup.sh` is a fallback for an image that ships no browser: paste it into the environment's Setup script field, and it installs Chrome. Nothing in the repository runs it. Network access can stay on Trusted either way, since the script pins a Chrome for Testing build rather than looking a channel name up on a host Trusted blocks. Add `cdn.playwright.dev` to a Custom allowlist if `pnpm export` should work there too, which also needs `playwright-chromium`, a package this repository does not depend on.
+The setup script in `.claude/cloud-setup.sh` is a fallback for an image that ships no browser: paste it into the environment's Setup script field, and it installs Chrome. Nothing in the repository runs it. Network access can stay on Trusted either way, since the script pins a Chrome for Testing build rather than looking a channel name up on a host Trusted blocks.
+
+### Exporting a PDF
+
+`pnpm export` needs `playwright-chromium`, which this repository deliberately does not depend on. The version matters: Playwright pins an exact Chromium revision, and the images at claude.ai/code ship revision 1194, which only 1.56.x asks for. Any other version looks for a revision that is not there and fails with `Executable doesn't exist at /opt/pw-browsers/chromium_headless_shell-<revision>`.
+
+```bash
+pnpm add -D playwright-chromium@1.56   # the revision the image already has
+pnpm export                            # first run times out on a cold cache
+pnpm export                            # second one writes slides-export.pdf
+```
+
+Pinned that way nothing is downloaded, so Trusted access is enough. Any other version fetches its own browser from `cdn.playwright.dev`, which needs a Custom allowlist.
+
+Install it for the session that needs a PDF and leave it out of a commit. The pin only matches whichever image is current, so carrying it in `package.json` would break on the next image bump and hold every other checkout to an old Playwright. The first run failing is Slidev's own export timing out while Vite still compiles, in `@slidev/cli` rather than in anything here.


### PR DESCRIPTION
Follow-up to #425, which left `pnpm export` as the last thing that does not work in a session at claude.ai/code. It turns out to work fine there, but only under conditions worth writing down.

## What the note said

> Add `cdn.playwright.dev` to a Custom allowlist if `pnpm export` should work there too, which also needs `playwright-chromium`, a package this repository does not depend on.

True, and not enough to act on. Installing `playwright-chromium` and allowlisting that host is in fact the *wrong* recipe: it downloads a browser the image already has, and the download is avoidable.

## What actually works

`@slidev/cli` declares `playwright-chromium ^1.10.0` as an optional peer dependency. Playwright pins an exact Chromium revision per release, so the only versions that work are the ones asking for the revision the image ships.

Bisected against `playwright-core`'s `browsers.json`:

| version | chromium revision |
| --- | --- |
| 1.55.x | 1187 |
| **1.56.x** | **1194** ← what the image ships |
| 1.57.x | 1200 |
| 1.58.x | 1208 |
| 1.62.1 (latest) | 1234 |

On latest, export dies before it opens a slide:

```
browserType.launch: Executable doesn't exist at
/opt/pw-browsers/chromium_headless_shell-1234/chrome-headless-shell-linux64/chrome-headless-shell
```

Pinned to `1.56`, nothing is downloaded at all — pnpm does not even run the postinstall — and the export succeeds. Trusted network access is enough; the allowlist entry is only needed by the versions that fetch their own browser.

## The first run always fails

With `node_modules/.vite` cleared, the first `pnpm export` ends in `TimeoutError` inside `genPagePdf`; running it again immediately succeeds. Same shape as the bug fixed in #424 — a wait that expires while Vite is still compiling — but this timeout lives in `@slidev/cli`, so it is not something this repository can fix. Documented as a two-run recipe instead.

## Why not just add the dependency

The pin works only because the image happens to ship chromium-1194 today. In `package.json` it would break on the next image bump and hold every other checkout to an old Playwright, in exchange for a command that still needs a retry on first use. So the docs say to install it for the session that needs a PDF and leave it out of the commit.

## Verification

Every claim above was run, not inferred:

- `pnpm add -D playwright-chromium@1.56` resolves to 1.56.1, which pins chromium 1194.
- With `node_modules/.vite` cleared: run 1 fails with `TimeoutError`, run 2 writes `slides-export.pdf` (250 KB, 18 page objects).
- On 1.62.1, the `Executable doesn't exist` failure above.
- The dependency was reverted afterwards; this PR changes `CLAUDE.md` only.
- `pnpm lint` clean, `pnpm test` 86/86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ggayx1Rt8451o5xV2cTdpa)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for exporting PDFs from cloud sessions.
  * Documented the required Playwright Chromium version, installation commands, first-run behavior, and access requirements.
  * Clarified that the temporary dependency should not be committed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->