### PR TITLE
Pin the export recipe to a patch version and undo it with git

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,11 +97,16 @@ The setup script in `.claude/cloud-setup.sh` is a fallback for an image that shi
 `pnpm export` needs `playwright-chromium`, which this repository deliberately does not depend on. The version matters: Playwright pins an exact Chromium revision, and the images at claude.ai/code ship revision 1194, which only 1.56.x asks for. Any other version looks for a revision that is not there and fails with `Executable doesn't exist at /opt/pw-browsers/chromium_headless_shell-<revision>`.
 
 ```bash
-pnpm add -D playwright-chromium@1.56   # the revision the image already has
-pnpm export                            # first run times out on a cold cache
-pnpm export                            # second one writes slides-export.pdf
+pnpm add -D playwright-chromium@1.56.1                    # the revision the image has
+pnpm export                                               # times out on a cold cache
+pnpm export                                               # writes slides-export.pdf
+git checkout package.json pnpm-lock.yaml && pnpm install  # put the tree back
 ```
 
+Name the patch version rather than a range. `@1.56` saves `~1.56.1`, which floats across 1.56 patches, and nothing promises they keep the same Chromium revision. Naming it in full saves it in full; `--save-exact` changes nothing, since it is the version spec that decides.
+
 Pinned that way nothing is downloaded, so Trusted access is enough. Any other version fetches its own browser from `cdn.playwright.dev`, which needs a Custom allowlist.
+
+Put the tree back with git rather than `pnpm remove`, which restores `package.json` but leaves the lockfile carrying both the package and the `(playwright-chromium@1.56.1)` peer suffix it added to `@slidev/cli`.
 
 Install it for the session that needs a PDF and leave it out of a commit. The pin only matches whichever image is current, so carrying it in `package.json` would break on the next image bump and hold every other checkout to an old Playwright. The first run failing is Slidev's own export timing out while Vite still compiles, in `@slidev/cli` rather than in anything here.


### PR DESCRIPTION
Addresses the review finding on #426, which merged before I could push the fix onto it.

The finding, on the export recipe added there:

> `pnpm add -D playwright-chromium@1.56` saves a caret range by default. A future install can resolve a newer Playwright 1.x release that expects a Chromium revision absent from the image. Use `--save-exact`, then run `pnpm remove -D playwright-chromium` after `pnpm export`.

The concern is right and the recipe is now stricter, but each of the three specifics turned out differently when run.

## What the version spec actually saves

Not a caret, and `--save-exact` is not the lever:

| command | saved in `package.json` |
| --- | --- |
| `pnpm add -D playwright-chromium@1.56` | `~1.56.1` |
| `pnpm add -D --save-exact playwright-chromium@1.56` | `~1.56.1` |
| `pnpm add -D playwright-chromium@1.56.1` | `1.56.1` |
| `pnpm add -D --save-exact playwright-chromium@1.56.1` | `1.56.1` |

The version spec decides; `--save-exact` changes nothing either way. A tilde also cannot reach 1.57, so the range could never have resolved a different minor's revision — but it does float across 1.56 patches, and nothing promises a patch keeps the same Chromium revision. So the recipe now names the patch version in full, which is what the finding was after.

## Why not `pnpm remove`

It restores `package.json` but leaves the lockfile dirty — the package entry, plus a `(playwright-chromium@1.56.1)` peer suffix added to `@slidev/cli`'s resolution, because the package is an optional peer dependency of it:

```
-        version: 52.6.0(@babel/parser@7.29.2)...(markdown-it-async@2.2.0)(postcss@8.5.10)
+        version: 52.6.0(@babel/parser@7.29.2)...(markdown-it-async@2.2.0)(playwright-chromium@1.56.1)(postcss@8.5.10)
```

That is exactly the accidental commit the surrounding text warns against, so the recipe ends with `git checkout package.json pnpm-lock.yaml && pnpm install` instead, and says why.

## Verification

The revised recipe was run verbatim from a cold cache (`node_modules/.vite` cleared):

- `pnpm add -D playwright-chromium@1.56.1` saves `1.56.1`.
- Export run 1 fails, run 2 writes `slides-export.pdf` (250 KB) — unchanged from #426.
- The closing `git checkout ... && pnpm install` leaves `git status` showing `CLAUDE.md` only, with `node_modules/playwright-chromium` gone.
- The four rows in the table above are each observed output, not inference.
- `pnpm lint` clean, `pnpm test` 86/86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ggayx1Rt8451o5xV2cTdpa)_