### PR TITLE
fix: Draw an arrow when the deck moves backward, as `v-click` content does

### DIFF
--- a/.changeset/olive-moons-return.md
+++ b/.changeset/olive-moons-return.md
@@ -1,0 +1,5 @@
+---
+"slidev-addon-fancy-arrow": patch
+---
+
+Draw an arrow whenever it comes into view, including when the deck moves backward, as Slidev's own `v-click` content does

--- a/.changeset/olive-moons-return.md
+++ b/.changeset/olive-moons-return.md
@@ -2,4 +2,4 @@
 "slidev-addon-fancy-arrow": patch
 ---
 
-Draw an arrow whenever it comes into view, including when the deck moves backward, as Slidev's own `v-click` content does
+Draw an arrow whenever it comes into view, including when the deck moves backward, as Slidev's own `v-click` content does. This undoes the 0.18.2 change that showed an arrow in its final state while the deck moved backward.

--- a/README.md
+++ b/README.md
@@ -108,9 +108,7 @@ The dash pattern scales with `width`, and applies to the line only so that the a
 
 ### Animation
 
-As the deck moves forward, an arrow draws itself once each time it appears. Once it has finished drawing, an arrow whose endpoints move follows them without drawing itself again for as long as it stays on screen.
-
-Stepping back to an earlier slide or click brings an arrow back in its final state, with no drawing.
+An arrow draws itself once each time it appears. Once it has finished drawing, an arrow whose endpoints move follows them without drawing itself again for as long as it stays on screen.
 
 #### Animation properties
 

--- a/components/FancyArrow.vue
+++ b/components/FancyArrow.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, useSlots, watch, onBeforeUpdate, onUpdated } from "vue";
+import { ref, computed, useSlots, onBeforeUpdate, onUpdated } from "vue";
 import {
   compileArrowEndpointProps,
   SnapTargetQuery,
@@ -141,7 +141,7 @@ const head = computed(() => {
   return getSnapTarget(headConfig);
 });
 
-const { isPrintMode, clicksDirection } = useNav();
+const { isPrintMode } = useNav();
 const isSlideActive = useIsSlideActive();
 function getSnapTarget(
   snapTargetQuery: SnapTargetQuery,
@@ -177,47 +177,6 @@ const animationEnabled = computed(() => {
     return false;
   }
   return props.static !== true;
-});
-
-// An arrow draws itself as the deck moves forward. Moving backward would replay a
-// drawing the audience has already seen, so while the deck moves backward the arrow is
-// shown as already drawn, by the rules at the end of this file. Slidev marks the
-// direction on the slide container, which is what those rules hang from, and reports it
-// here as well: https://sli.dev/features/direction-variant
-const movingBackward = computed(() => clicksDirection.value < 0);
-
-// The parts of an arrow the rules paint over. Whatever a slot's contents animate is
-// their own business, so this leaves those animations alone.
-const PAINTED_PARTS_SELECTOR =
-  ".animated-rough-arrow-stroke, .animated-rough-arrow-fill, .animated-rough-arrow-content";
-
-function getPaintedAnimations(): Animation[] {
-  const parts = root.value?.querySelectorAll(PAINTED_PARTS_SELECTOR) ?? [];
-  return Array.from(parts).flatMap((part) => part.getAnimations());
-}
-
-// Those rules only paint over the animation, which is still running underneath and
-// would carry on in view once the deck moves forward again, so it is sent to its end
-// as soon as it starts.
-function onAnimationStart(event: AnimationEvent) {
-  if (!movingBackward.value || !(event.target instanceof Element)) {
-    return;
-  }
-  if (!event.target.matches(PAINTED_PARTS_SELECTOR)) {
-    return;
-  }
-  event.target.getAnimations().forEach((animation) => animation.finish());
-}
-
-// A path only reports its animation starting once its turn in the stagger comes round,
-// and the paths still waiting are held together by the painting alone. They would fall
-// back to being undrawn the moment the deck turns around and the painting stops, so the
-// whole arrow is sent to its end first.
-watch(movingBackward, (backward) => {
-  if (backward) {
-    return;
-  }
-  getPaintedAnimations().forEach((animation) => animation.finish());
 });
 
 const { arrowSvg, textPosition } = useRoughArrow({
@@ -270,7 +229,7 @@ onUpdated(() => {
 </script>
 
 <template>
-  <div ref="root" style="display: contents" @animationstart="onAnimationStart">
+  <div ref="root" style="display: contents">
     <!--
     "display: contents" ensures the root element doesn't affect the layout
     so that the positions of the elements injected into the slots are not
@@ -379,40 +338,15 @@ onUpdated(() => {
   animation: rough-arrow-content ease-out forwards;
 }
 
-/*
-Stop animation when this element is hidden due to v-click.
-The `visibility` keeps the arrow hidden against the rules further down that show it as
-already drawn. Slidev hides it by turning the opacity down, which has no effect on the
-`display: contents` element the arrow hangs from.
-*/
+/* Stop animation when this element is hidden due to v-click */
 .slidev-vclick-target.slidev-vclick-hidden .animated-rough-arrow-stroke {
   animation: none;
-  visibility: hidden !important;
 }
 .slidev-vclick-target.slidev-vclick-hidden .animated-rough-arrow-fill {
   animation: none;
-  visibility: hidden !important;
 }
 .slidev-vclick-target.slidev-vclick-hidden .animated-rough-arrow-content {
   animation: none;
-  visibility: hidden !important;
-}
-
-/*
-Show the arrow as already drawn while the deck is moving backward, rather than let it
-draw a picture the audience has already seen.
-Slidev marks the direction on the slide container (https://sli.dev/features/direction-variant),
-which reaches an arrow however it came on screen.
-`!important` puts these above the animation, which the cascade otherwise ranks above
-the styles each path is built with.
-*/
-.slidev-nav-go-backward .animated-rough-arrow-stroke,
-.slidev-nav-go-backward .animated-rough-arrow-fill,
-.slidev-nav-go-backward .animated-rough-arrow-content {
-  visibility: visible !important;
-}
-.slidev-nav-go-backward .animated-rough-arrow-stroke {
-  stroke-dashoffset: 0 !important;
 }
 
 /*


### PR DESCRIPTION
An arrow was shown in its final state while the deck moved backward, rather than drawing itself, on the grounds that replaying a drawing the audience had already seen was noise. Slidev's own `v-click` content makes no such distinction and animates in whichever direction the deck moves, so this reverts #418, released as 0.18.2, and an arrow draws itself again whenever it comes into view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L55D2JmQM1pZCdQE9YKCHi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Behavior Changes**
  - Arrows now draw their animation whenever they come into view, including when navigating backward through the deck.
  - Arrow animations now behave consistently with Slidev’s click animations.
  - Removed the behavior that displayed arrows in their completed state during backward navigation.

- **Documentation**
  - Updated animation guidance to reflect the new navigation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->