### PR TITLE
feat: Snap an arrow to a line of a code block with a `{n}` shorthand

### DIFF
--- a/.changeset/spotty-hoops-listen.md
+++ b/.changeset/spotty-hoops-listen.md
@@ -1,0 +1,5 @@
+---
+"slidev-addon-fancy-arrow": minor
+---
+
+Add a line specifier to the endpoint shorthand, so an arrow snaps to a line of a code block without a hand-written `:nth-child()` selector. `to="[data-id=code]{3}"` takes the third line of the matched code block, `{3-5}` takes the box covering a range, and `{1,3-5}` takes several lines or ranges at once. Lines are counted from `1`, the same way Slidev's own line highlighting counts them, and a line specifier on its own, as in `to="{3}"`, takes the first code block on the slide. The long form of the same thing is the new `line1` and `line2` props.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,39 @@ See also: https://sli.dev/guide/theme-addon#use-addon
 <FancyArrow from="[data-id=anchor1]@bottom" to="[data-id=anchor2]@top" />
 ```
 
+#### Snap to a line of a code block
+
+A line specifier `{n}` after the selector snaps to a line of the code block the selector matches, instead of to the code block as a whole. Lines are counted from `1`, the same way Slidev's own [line highlighting](https://sli.dev/features/line-highlighting) counts them.
+
+````md
+```js {*}{'data-id':'code'}
+for (const item of items) {
+  console.log(item);
+}
+```
+
+<FancyArrow from="[data-id=note]@left" to="[data-id=code]{2}@right" />
+````
+
+`{n-m}` snaps to the box that covers a range of lines, and `{n,m-o}` takes several lines or ranges at once.
+
+```html
+<FancyArrow to="[data-id=code]{2-4}" from="(500, 300)" />
+<FancyArrow to="[data-id=code]{1,3-4}" from="(500, 300)" />
+```
+
+A line specifier on its own takes the first code block on the slide, which is all a slide with a single code block needs.
+
+```html
+<FancyArrow to="{2}@right" from="(500, 300)" />
+```
+
+The long form is `line1` and `line2`, alongside `q1`/`q2` and `pos1`/`pos2`.
+
+```html
+<FancyArrow q2="[data-id=code]" line2="2" pos2="right" x1="500" y1="300" />
+```
+
 #### Define the snapped elements via `tail` and `head` slots
 
 ```html

--- a/components/FancyArrow.vue
+++ b/components/FancyArrow.vue
@@ -17,6 +17,7 @@ import {
   type LineStyle,
 } from "./use-rough-arrow";
 import ChildElementPicker from "./ChildElementPicker.vue";
+import { pickCodeLineElements } from "./code-lines";
 
 const props = defineProps<{
   from?: string; // Shorthand for (q1 and pos1) or (x1 and y1)
@@ -27,6 +28,8 @@ const props = defineProps<{
   id2?: string; // Deprecated
   pos1?: SnapAnchorPoint;
   pos2?: SnapAnchorPoint;
+  line1?: number | string;
+  line2?: number | string;
   x1?: number | string;
   y1?: number | string;
   x2?: number | string;
@@ -73,7 +76,7 @@ const tail = computed(() => {
   const useTailSlot = slots.tail != null;
   if (useTailSlot) {
     const snapTarget: SnapTarget = {
-      element: tailElementRef.value,
+      elements: tailElementRef.value ? [tailElementRef.value] : [],
       snapPosition: undefined,
     };
     return snapTarget;
@@ -84,14 +87,16 @@ const tail = computed(() => {
     q: props.q1,
     id: props.id1,
     pos: props.pos1,
+    line: props.line1,
     x: props.x1,
     y: props.y1,
   });
 
   if (tailConfig == null) {
     // Try to use the next or previous element as fallback snap target.
+    const previousElement = root.value?.previousElementSibling;
     const snapTarget: SnapTarget = {
-      element: root.value?.previousElementSibling ?? undefined,
+      elements: previousElement ? [previousElement] : [],
       snapPosition: undefined,
     };
     return snapTarget;
@@ -109,7 +114,7 @@ const head = computed(() => {
   const useHeadSlot = slots.head != null;
   if (useHeadSlot) {
     const snapTarget: SnapTarget = {
-      element: headElementRef.value,
+      elements: headElementRef.value ? [headElementRef.value] : [],
       snapPosition: undefined,
     };
     return snapTarget;
@@ -120,14 +125,16 @@ const head = computed(() => {
     q: props.q2,
     id: props.id2,
     pos: props.pos2,
+    line: props.line2,
     x: props.x2,
     y: props.y2,
   });
 
   if (headConfig == null) {
     // Try to use the next or previous element as fallback snap target.
+    const nextElement = root.value?.nextElementSibling;
     const snapTarget: SnapTarget = {
-      element: root.value?.nextElementSibling ?? undefined,
+      elements: nextElement ? [nextElement] : [],
       snapPosition: undefined,
     };
     return snapTarget;
@@ -153,14 +160,18 @@ function getSnapTarget(
     return undefined;
   }
 
-  const element =
-    slideContainer.value?.querySelector(snapTargetQuery.query) ?? undefined;
+  const element = slideContainer.value?.querySelector(snapTargetQuery.query);
   if (element == null) {
     console.warn(`Element not found for query: ${snapTargetQuery.query}`);
   }
 
   const snapTarget: SnapTarget = {
-    element,
+    elements:
+      element == null
+        ? []
+        : snapTargetQuery.lines
+          ? pickCodeLineElements(element, snapTargetQuery.lines)
+          : [element],
     snapPosition: snapTargetQuery.snapPosition,
   };
   return snapTarget;

--- a/components/code-lines.test.ts
+++ b/components/code-lines.test.ts
@@ -1,0 +1,65 @@
+// @vitest-environment happy-dom
+import { describe, it, expect } from "vitest";
+import { pickCodeLineElements } from "./code-lines";
+
+function codeBlock(lineCount: number): Element {
+  const pre = document.createElement("pre");
+  pre.className = "slidev-code";
+  const code = document.createElement("code");
+  for (let i = 1; i <= lineCount; i++) {
+    const line = document.createElement("span");
+    line.className = "line";
+    line.textContent = `line ${i}`;
+    code.appendChild(line);
+    code.appendChild(document.createTextNode("\n"));
+  }
+  pre.appendChild(code);
+  return pre;
+}
+
+function texts(elements: Element[]): (string | null)[] {
+  return elements.map((element) => element.textContent);
+}
+
+describe("pickCodeLineElements", () => {
+  it("picks a single line, counting from 1", () => {
+    expect(
+      texts(pickCodeLineElements(codeBlock(5), [{ start: 3, end: 3 }])),
+    ).toEqual(["line 3"]);
+  });
+
+  it("picks every line of a range", () => {
+    expect(
+      texts(pickCodeLineElements(codeBlock(5), [{ start: 2, end: 4 }])),
+    ).toEqual(["line 2", "line 3", "line 4"]);
+  });
+
+  it("returns the lines of several ranges in document order, without duplicates", () => {
+    expect(
+      texts(
+        pickCodeLineElements(codeBlock(5), [
+          { start: 4, end: 5 },
+          { start: 1, end: 1 },
+          { start: 4, end: 4 },
+        ]),
+      ),
+    ).toEqual(["line 1", "line 4", "line 5"]);
+  });
+
+  it("drops lines beyond the end of the code block", () => {
+    expect(
+      texts(pickCodeLineElements(codeBlock(3), [{ start: 2, end: 9 }])),
+    ).toEqual(["line 2", "line 3"]);
+    expect(pickCodeLineElements(codeBlock(3), [{ start: 9, end: 9 }])).toEqual(
+      [],
+    );
+  });
+
+  it("returns nothing when the target holds no code lines", () => {
+    expect(
+      pickCodeLineElements(document.createElement("div"), [
+        { start: 1, end: 1 },
+      ]),
+    ).toEqual([]);
+  });
+});

--- a/components/code-lines.ts
+++ b/components/code-lines.ts
@@ -1,0 +1,45 @@
+import type { LineRange } from "./parse-option";
+
+/**
+ * Shiki, which Slidev renders code blocks with, wraps every line of a code block
+ * in a `<span class="line">`.
+ */
+export const CODE_LINE_SELECTOR = ".line";
+
+/**
+ * Picks the elements of the given lines out of a code block, in document order.
+ *
+ * Line numbers are 1-based and count the rendered lines, the same way Slidev's own
+ * line-highlighting syntax does. Out-of-range lines are dropped rather than clamped,
+ * so that a stale line number doesn't silently point at the wrong line.
+ */
+export function pickCodeLineElements(
+  codeBlock: Element,
+  lines: LineRange[],
+): Element[] {
+  const lineElements = Array.from(
+    codeBlock.querySelectorAll(CODE_LINE_SELECTOR),
+  );
+  if (lineElements.length === 0) {
+    console.warn(
+      "No code lines found in the snap target. A line specifier such as {3} only works on a code block.",
+    );
+    return [];
+  }
+
+  const picked = new Set<Element>();
+  for (const { start, end } of lines) {
+    if (start > lineElements.length) {
+      console.warn(
+        `Line ${start} is out of range: the code block has ${lineElements.length} lines.`,
+      );
+      continue;
+    }
+    for (let line = start; line <= Math.min(end, lineElements.length); line++) {
+      picked.add(lineElements[line - 1]);
+    }
+  }
+
+  // Ranges may be given out of order, so sort back into document order.
+  return lineElements.filter((element) => picked.has(element));
+}

--- a/components/parse-option.test.ts
+++ b/components/parse-option.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { parseArrowEndpointShorthand } from "./parse-option";
+import {
+  compileArrowEndpointProps,
+  parseArrowEndpointShorthand,
+} from "./parse-option";
 
 describe("parsePosition", () => {
   (
@@ -134,6 +137,102 @@ describe("parsePosition", () => {
         query: expectedQuery,
         snapPosition: expectedSnapPosition,
       });
+    });
+  });
+});
+
+describe("line specifiers", () => {
+  (
+    [
+      [
+        "[data-id=code]{3}",
+        "[data-id=code]",
+        [{ start: 3, end: 3 }],
+        undefined,
+      ],
+      [
+        "[data-id=code]{3-5}",
+        "[data-id=code]",
+        [{ start: 3, end: 5 }],
+        undefined,
+      ],
+      [
+        "[data-id=code]{1,3-5}",
+        "[data-id=code]",
+        [
+          { start: 1, end: 1 },
+          { start: 3, end: 5 },
+        ],
+        undefined,
+      ],
+      [
+        "[data-id=code]{3}@left",
+        "[data-id=code]",
+        [{ start: 3, end: 3 }],
+        "left",
+      ],
+      [
+        " [data-id=code] { 3 - 5 } @ left ",
+        "[data-id=code]",
+        [{ start: 3, end: 5 }],
+        "left",
+      ],
+      // A reversed range means the same lines as the forward one.
+      [
+        "[data-id=code]{5-3}",
+        "[data-id=code]",
+        [{ start: 3, end: 5 }],
+        undefined,
+      ],
+      // Without a selector, the line specifier takes the slide's first code block.
+      ["{3}", ".slidev-code", [{ start: 3, end: 3 }], undefined],
+      ["{3-5}@right", ".slidev-code", [{ start: 3, end: 5 }], "right"],
+    ] as const
+  ).forEach(
+    ([optionString, expectedQuery, expectedLines, expectedSnapPosition]) => {
+      it(`parses a line specifier correctly: "${optionString}"`, () => {
+        expect(parseArrowEndpointShorthand(optionString)).toEqual({
+          query: expectedQuery,
+          lines: expectedLines,
+          snapPosition: expectedSnapPosition,
+        });
+      });
+    },
+  );
+
+  it("keeps a selector without a line specifier free of lines", () => {
+    expect(parseArrowEndpointShorthand("[data-id=code]")).not.toHaveProperty(
+      "lines",
+    );
+  });
+
+  (["{}", "{0}", "{abc}", "{1-}", "{-1}", "{1.5}"] as const).forEach(
+    (optionString) => {
+      it(`rejects an invalid line specifier: "${optionString}"`, () => {
+        expect(() => parseArrowEndpointShorthand(optionString)).toThrow();
+      });
+    },
+  );
+
+  it("compiles the `line` prop into lines", () => {
+    expect(
+      compileArrowEndpointProps({
+        q: "[data-id=code]",
+        line: "3-5",
+        pos: "left",
+      }),
+    ).toEqual({
+      query: "[data-id=code]",
+      lines: [{ start: 3, end: 5 }],
+      snapPosition: "left",
+    });
+  });
+
+  it("takes the first code block when `line` comes without `q`", () => {
+    expect(compileArrowEndpointProps({ line: 3 })).toEqual({
+      query: ".slidev-code",
+      lines: [{ start: 3, end: 3 }],
+      snapPosition: undefined,
     });
   });
 });

--- a/components/parse-option.ts
+++ b/components/parse-option.ts
@@ -21,16 +21,35 @@ export interface Position {
   y: LengthPercentage;
 }
 
+/** A 1-based, inclusive range of lines inside a code block. */
+export interface LineRange {
+  start: number;
+  end: number;
+}
+
 export interface SnapTargetQuery {
   query: string;
+  /**
+   * When set, the arrow snaps to the lines of the code block matched by `query`
+   * instead of the code block as a whole.
+   */
+  lines?: LineRange[];
   snapPosition: SnapAnchorPoint | Position | undefined;
 }
+
+/**
+ * The code block a line specifier resolves against when it comes without a selector,
+ * as in "{3}". It is the class Slidev puts on every code block it renders.
+ */
+export const DEFAULT_CODE_BLOCK_SELECTOR = ".slidev-code";
 
 const ZERO_LENGTH_PERCENTAGE: LengthPercentage = { value: 0, unit: "px" };
 
 const lengthPercentageRegex = /(?<value>[+-]?\d+)(?<unit>%|px)?/;
 const positionRegex = /^\(\s*(?<x>\S+)\s*,\s*(?<y>\S+)\s*\)$/;
-const snapTargetRegex = /^(?<query>[^@]+?)(@\s*(?<snapPosition>.+?))?$/;
+const snapTargetRegex =
+  /^(?<query>[^@{}]*?)\s*(\{(?<lines>[^{}]*)\})?\s*(@\s*(?<snapPosition>.+?))?$/;
+const lineRangeRegex = /^(?<start>\d+)(\s*-\s*(?<end>\d+))?$/;
 
 function parseLengthPercentage(
   lengthString: string,
@@ -77,9 +96,43 @@ function parseSnapPosition(
 }
 
 /**
- * The `arrowEndpointShorthand` can be in the format of a CSS selector with a snap position,
- * or a position in the format "(x,y)".
+ * Parses a line specifier such as "3", "3-5", or "1,3-5" into 1-based inclusive ranges.
+ * The syntax mirrors Slidev's line-highlighting syntax, so ```ts {3-5} and "{3-5}" here
+ * mean the same lines.
+ */
+export function parseLineSpec(lineSpecString: string): LineRange[] {
+  const specs = lineSpecString
+    .split(",")
+    .map((spec) => spec.trim())
+    .filter((spec) => spec !== "");
+  if (specs.length === 0) {
+    throw new Error(`Invalid line specifier: "${lineSpecString}" is empty`);
+  }
+
+  return specs.map((spec) => {
+    const match = spec.match(lineRangeRegex);
+    if (!match) {
+      throw new Error(`Invalid line specifier: "${spec}"`);
+    }
+    const start = parseInt(match.groups?.start ?? "", 10);
+    const end =
+      match.groups?.end != null ? parseInt(match.groups.end, 10) : start;
+    if (start < 1 || end < 1) {
+      throw new Error(
+        `Invalid line specifier: "${spec}", line numbers start at 1`,
+      );
+    }
+    // A reversed range like "5-3" means the same lines as "3-5".
+    return { start: Math.min(start, end), end: Math.max(start, end) };
+  });
+}
+
+/**
+ * The `arrowEndpointShorthand` can be in the format of a CSS selector with an optional
+ * line specifier and an optional snap position, or a position in the format "(x,y)".
  * - For example, "[data-id=snap-target]" or "[data-id=snap-target]@left".
+ * - A line of a code block like "[data-id=code]{3}", a range like "[data-id=code]{3-5}",
+ *   or "{3}" on its own, which takes the first code block on the slide.
  * - Or a position like "(100,200)", "(100px,200px)", or (10%,20%).
  */
 export function parseArrowEndpointShorthand(
@@ -94,15 +147,18 @@ export function parseArrowEndpointShorthand(
 
   const snapTargetMatch = arrowEndpointShorthand.match(snapTargetRegex);
   if (snapTargetMatch) {
-    const query = snapTargetMatch.groups?.query;
-    if (!query) {
+    const query = snapTargetMatch.groups?.query?.trim();
+    const lineSpec = snapTargetMatch.groups?.lines;
+    if (!query && lineSpec == null) {
       throw new Error(
         `Invalid arrow endpoint format: missing query group in "${arrowEndpointShorthand}"`,
       );
     }
     const snapPosition = snapTargetMatch.groups?.snapPosition;
     return {
-      query: query.trim(),
+      // A line specifier on its own points at the slide's first code block.
+      query: query || DEFAULT_CODE_BLOCK_SELECTOR,
+      ...(lineSpec != null && { lines: parseLineSpec(lineSpec) }),
       snapPosition: snapPosition ? parseSnapPosition(snapPosition) : undefined,
     };
   }
@@ -115,6 +171,7 @@ interface ArrowEndpointProps {
   q?: string;
   id?: string; // Deprecated
   pos?: SnapAnchorPoint;
+  line?: number | string;
   x?: number | string;
   y?: number | string;
 }
@@ -130,16 +187,27 @@ export function compileArrowEndpointProps(
     }
   }
 
-  if (props.q) {
+  if (props.q || props.id || props.line != null) {
+    // `id` is deprecated in favour of `q`.
+    const query =
+      props.q ||
+      (props.id ? `#${props.id}` : undefined) ||
+      // A line without a selector points at the slide's first code block.
+      DEFAULT_CODE_BLOCK_SELECTOR;
+
+    let lines: LineRange[] | undefined;
+    if (props.line != null) {
+      try {
+        lines = parseLineSpec(String(props.line));
+      } catch (error) {
+        console.error(`Failed to parse line "${String(props.line)}":`, error);
+        return undefined;
+      }
+    }
+
     return {
-      query: props.q,
-      snapPosition: props.pos ? parseSnapPosition(props.pos) : undefined,
-    };
-  }
-  if (props.id) {
-    // Deprecated
-    return {
-      query: `#${props.id}`,
+      query,
+      ...(lines && { lines }),
       snapPosition: props.pos ? parseSnapPosition(props.pos) : undefined,
     };
   }

--- a/components/position.ts
+++ b/components/position.ts
@@ -37,8 +37,38 @@ function getAbsoluteValue(
 }
 
 export interface SnapTarget {
-  element: Element | undefined;
+  /**
+   * The elements the arrow snaps to. More than one when the target spans several
+   * elements, such as a range of code block lines, in which case the arrow snaps to
+   * the box that covers them all.
+   */
+  elements: Element[];
   snapPosition: SnapAnchorPoint | Position | undefined;
+}
+
+interface Rect {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+}
+
+function getUnionRect(elements: Element[]): Rect | undefined {
+  // An element that renders nothing at all reports an empty rect at the origin, which
+  // would stretch the union far beyond the elements that are actually on screen.
+  const rects = elements
+    .map((element) => element.getBoundingClientRect())
+    .filter((rect) => rect.width > 0 || rect.height > 0);
+  if (rects.length === 0) {
+    return elements[0]?.getBoundingClientRect();
+  }
+
+  return {
+    left: Math.min(...rects.map((rect) => rect.left)),
+    top: Math.min(...rects.map((rect) => rect.top)),
+    right: Math.max(...rects.map((rect) => rect.right)),
+    bottom: Math.max(...rects.map((rect) => rect.bottom)),
+  };
 }
 
 export interface BoxPosition {
@@ -68,19 +98,19 @@ export function resolveSnapTargetPosition(
 
     const snapTarget = endpointRef.value;
 
-    const { element, snapPosition } = snapTarget;
-    if (!rootElementRef.value || !element) {
+    const { elements, snapPosition } = snapTarget;
+    const rect = getUnionRect(elements);
+    if (!rootElementRef.value || !rect) {
       position.value = undefined;
       return;
     }
 
-    const rect = element.getBoundingClientRect();
     const rootRect = rootElementRef.value.getBoundingClientRect();
 
     const x = (rect.left - rootRect.left) / $scale.value;
     const y = (rect.top - rootRect.top) / $scale.value;
-    const width = rect.width / $scale.value;
-    const height = rect.height / $scale.value;
+    const width = (rect.right - rect.left) / $scale.value;
+    const height = (rect.bottom - rect.top) / $scale.value;
 
     if (
       position.value &&
@@ -115,9 +145,11 @@ export function resolveSnapTargetPosition(
       if ("x" in newVal) {
         // Sync Position -> Position
         position.value = newVal;
-      } else if (newVal.element) {
+      } else if (newVal.elements.length > 0) {
         const observer = new MutationObserver(updateSnappedPosition);
-        observer.observe(newVal.element, { attributes: true });
+        newVal.elements.forEach((element) => {
+          observer.observe(element, { attributes: true });
+        });
 
         onWatcherCleanup(() => {
           observer.disconnect();

--- a/slides.md
+++ b/slides.md
@@ -940,20 +940,66 @@ for(let i = 1; i <= 100; i++) {
 
 </div>
 
-<FancyArrow from="[data-id=description-loop]@left" to="[data-id=code-block] .line:nth-child(1) @ right" />
-<FancyArrow from="[data-id=description-15]@left" to="[data-id=code-block] .line:nth-child(3) @ right" color="orange" />
-<FancyArrow from="[data-id=description-5]@left" to="[data-id=code-block] .line:nth-child(5) @ right" color="yellow" />
-<FancyArrow from="[data-id=description-3]@left" to="[data-id=code-block] .line:nth-child(7) @ right" color="green" />
-<FancyArrow from="[data-id=description-else]@left" to="[data-id=code-block] .line:nth-child(9) @ right" color="cyan" />
+<FancyArrow from="[data-id=description-loop]@left" to="[data-id=code-block]{1}@right" />
+<FancyArrow from="[data-id=description-15]@left" to="[data-id=code-block]{3}@right" color="orange" />
+<FancyArrow from="[data-id=description-5]@left" to="[data-id=code-block]{5}@right" color="yellow" />
+<FancyArrow from="[data-id=description-3]@left" to="[data-id=code-block]{7}@right" color="green" />
+<FancyArrow from="[data-id=description-else]@left" to="[data-id=code-block]{9}@right" color="cyan" />
 
 
 ```html
-<FancyArrow to="[data-id=code-block] .line:nth-child(1) @ right" from="[data-id=description-loop]@left" />
-<FancyArrow to="[data-id=code-block] .line:nth-child(3) @ right" from="[data-id=description-15]@left" color="orange" />
-<FancyArrow to="[data-id=code-block] .line:nth-child(5) @ right" from="[data-id=description-5]@left" color="yellow" />
-<FancyArrow to="[data-id=code-block] .line:nth-child(7) @ right" from="[data-id=description-3]@left" color="green" />
-<FancyArrow to="[data-id=code-block] .line:nth-child(9) @ right" from="[data-id=description-else]@left" color="cyan" />
+<FancyArrow to="[data-id=code-block]{1}@right" from="[data-id=description-loop]@left" />
+<FancyArrow to="[data-id=code-block]{3}@right" from="[data-id=description-15]@left" color="orange" />
+<FancyArrow to="[data-id=code-block]{5}@right" from="[data-id=description-5]@left" color="yellow" />
+<FancyArrow to="[data-id=code-block]{7}@right" from="[data-id=description-3]@left" color="green" />
+<FancyArrow to="[data-id=code-block]{9}@right" from="[data-id=description-else]@left" color="cyan" />
 ```
+
+---
+
+# Line specifiers
+
+`{n}` after a selector snaps to a line of the code block it matches, counting rendered lines from `1` just like Slidev's own `{n}` line highlighting. A range `{n-m}` snaps to the box that covers those lines.
+
+<div grid="~ cols-2" gap-4 mt-4>
+
+<div>
+
+```py {*}{'data-id':'lines-demo'}
+def fizzbuzz(n):
+    if n % 15 == 0:
+        return "FizzBuzz"
+    if n % 5 == 0:
+        return "Buzz"
+    return str(n)
+```
+
+</div>
+
+<div text-sm>
+
+<div data-id="lines-desc-1" p-2>`{1}` — one line</div>
+<div data-id="lines-desc-2" p-2>`{2-5}` — a range of lines</div>
+<div data-id="lines-desc-3" p-2>`{6}@bottomright` — a line with an anchor point</div>
+
+</div>
+
+</div>
+
+<FancyArrow from="[data-id=lines-desc-1]@left" to="[data-id=lines-demo]{1}@right" />
+<FancyArrow from="[data-id=lines-desc-2]@left" to="[data-id=lines-demo]{2-5}" color="orange" />
+<FancyArrow from="[data-id=lines-desc-3]@left" to="[data-id=lines-demo]{6}@bottomright" color="green" arc="0.2" />
+
+```html
+<FancyArrow from="[data-id=lines-desc-1]@left" to="[data-id=lines-demo]{1}@right" />
+<FancyArrow from="[data-id=lines-desc-2]@left" to="[data-id=lines-demo]{2-5}" color="orange" />
+<FancyArrow from="[data-id=lines-desc-3]@left" to="[data-id=lines-demo]{6}@bottomright" color="green" arc="0.2" />
+```
+
+<div m-2 text-sm>
+
+A line specifier on its own, like `to="{3}"`, takes the first code block on the slide, and the long form `q2="[data-id=code]" line2="3"` does the same as `to="[data-id=code]{3}"`.
+</div>
 
 ---
 transition: slide-left
@@ -1026,3 +1072,4 @@ clicks: 4
 <div absolute right-10 top="50%" translate-x="-50%" translate-y="-50%" data-id="right-anchor">Anchor</div>
 
 <FancyArrow q1="[data-id=center-anchor]" :x2="$clicks % 2 === 0 ? 100 : 900" :y2="$clicks / 2 < 1 ? 100 : 500" :q2="$clicks > 3 ? '[data-id=right-anchor]' : undefined" />
+


### PR DESCRIPTION
Closes #184.

## The shorthand

A line specifier goes after the selector, before the `@` anchor point:

```
[data-id=code]{3}@right
```

| Form | Means |
| --- | --- |
| `{3}` | the third rendered line |
| `{3-5}` | the box covering lines 3 through 5 |
| `{1,3-5}` | several lines or ranges at once |
| `{3}` with no selector | line 3 of the slide's first code block |
| `{3}@left` | line 3, anchored at its left edge |

The numbers mirror Slidev's own [line highlighting](https://sli.dev/features/line-highlighting), so the `{3-5}` in ` ```js {3-5} ` and the `{3-5}` in an arrow mean the same lines. `{` and `}` cannot appear in a CSS selector, so the suffix is unambiguous next to one.

Before and after, from the existing demo slide:

```html
<FancyArrow to="[data-id=code-block] .line:nth-child(3) @ right" from="[data-id=description-15]@left" />
<FancyArrow to="[data-id=code-block]{3}@right" from="[data-id=description-15]@left" />
```

The long form of the same thing is the new `line1` / `line2` props, alongside `q1` / `q2` and `pos1` / `pos2`:

```html
<FancyArrow q2="[data-id=code]" line2="3" pos2="right" x1="500" y1="300" />
```

## Implementation

- `parse-option.ts` grows a `{…}` group in the endpoint regex and a `parseLineSpec` that turns `3`, `3-5`, `1,3-5` into 1-based inclusive `LineRange`s. A specifier with no selector defaults the query to `.slidev-code`, the class Slidev puts on every code block it renders.
- `code-lines.ts` (new) picks the `<span class="line">` elements — Shiki's per-line markup — out of the matched code block, in document order, without duplicates. Lines past the end of the block are dropped with a warning rather than clamped, so a stale line number does not silently point at the wrong line.
- A range snaps to the box covering its lines, so `SnapTarget` now holds a set of elements rather than one, and `position.ts` takes their union rect. Everything downstream — anchor points, auto-snap, animation — works off that box unchanged, so `{3-5}@left` and auto-snap behave as they do for any other target.

## Docs

`README.md` gains a "Snap to a line of a code block" section. In `slides.md`, the existing "Demo: Snapped to a line in a code block" slide is rewritten to the shorthand, and a new "Line specifiers" slide documents single lines, ranges, and anchor points.

## Verification

`pnpm test` (108 passing, including new cases for the parser and for line picking), `pnpm lint`, `pnpm format --check`, and `pnpm build` all pass. The demo slides were rendered to PNGs and checked, including a scratch slide covering the bare `{n}` form, the `line1`/`line2` props, a blank line, and a range spanning one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01396etdgMzKCWaVisNqbxm4)_