### PR TITLE
Deploy the demo to Cloudflare Pages instead of GitHub Pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,10 @@ jobs:
   build-demo:
     needs: [test]
 
+    permissions:
+      contents: read
+      pull-requests: write # To comment a pull request's preview URL.
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -69,29 +73,66 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      # No --base: Cloudflare Pages serves the demo from the root of its own domain.
       - name: Build
-        run: pnpm build --base /${{ github.event.repository.name }}/
+        run: pnpm build
 
-      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
-        with:
-          path: dist/
+      # Deploying from the build job keeps the artifact in place, so no upload and
+      # download round trip is needed. A fork's pull request cannot read the secrets,
+      # so it builds as a check and stops there.
+      - name: Deploy to Cloudflare Pages
+        id: deploy
+        if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # Cloudflare deploys the project's production branch to the production URL
+          # and every other branch to a preview of its own, so passing the branch
+          # through is what makes a pull request preview appear.
+          BRANCH: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+        run: |
+          set -euo pipefail
+          # Run through pnpm rather than a third-party action so the install is
+          # covered by Safe Chain above, and pin the version for the same reason
+          # every action here is pinned.
+          pnpm dlx wrangler@4.127.1 pages deploy dist \
+            --project-name slidev-addon-fancy-arrow \
+            --branch "$BRANCH" | tee deploy.log
+          # A branch deploy also gets an alias that stays put across pushes, which is
+          # the more useful link; production only prints the one URL. Both greps end
+          # in `|| true` because a miss is expected and would otherwise, under
+          # `pipefail`, end the step before the fallback runs.
+          url="$(grep -Eo 'alias URL: *https://[a-z0-9.-]+\.pages\.dev' deploy.log | grep -Eo 'https://.*' | tail -1 || true)"
+          if [ -z "$url" ]; then
+            url="$(grep -Eo 'https://[a-z0-9-]+\.[a-z0-9-]+\.pages\.dev' deploy.log | tail -1 || true)"
+          fi
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+          if [ -n "$url" ]; then
+            echo "Deployed $BRANCH to $url" >> "$GITHUB_STEP_SUMMARY"
+          else
+            # The deploy itself succeeded, so this is not worth failing the build over.
+            echo "Deployed $BRANCH, but could not read a URL out of wrangler's output." >> "$GITHUB_STEP_SUMMARY"
+          fi
 
-  deploy-demo:
-    needs: [build-demo]
-    if: ${{ github.event_name == 'push' && github.ref_name == github.event.repository.default_branch }}
-
-    permissions:
-      pages: write
-      id-token: write
-
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
-    runs-on: ubuntu-latest
-    steps:
-      - id: deployment
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+      # One comment that gets rewritten, rather than a new one per push.
+      - name: Comment the preview URL
+        if: ${{ github.event_name == 'pull_request' && steps.deploy.outputs.url != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          URL: ${{ steps.deploy.outputs.url }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          marker="<!-- cloudflare-pages-preview -->"
+          body="$(printf '%s\n\n[Preview this branch](%s), built from %s.' "$marker" "$URL" "${SHA:0:7}")"
+          id="$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR/comments" --paginate \
+            --jq "map(select(.body | startswith(\"$marker\"))) | .[0].id // empty")"
+          if [ -n "$id" ]; then
+            gh api -X PATCH "repos/$GITHUB_REPOSITORY/issues/comments/$id" -f body="$body"
+          else
+            gh api -X POST "repos/$GITHUB_REPOSITORY/issues/$PR/comments" -f body="$body"
+          fi
 
   release:
     needs: [build-demo] # Semantically, this job can be run just after test, but we wait for build-demo to ensure the build is successful.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,39 +83,47 @@ jobs:
       - name: Deploy to Cloudflare Pages
         id: deploy
         if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
-        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          # The action installs wrangler with this repository's own package manager,
-          # so Safe Chain covers it. Pin it as everything else here is pinned, to a
-          # release old enough for Safe Chain's minimum-age filter to have let it
-          # through: too new a pin fails as ERR_PNPM_NO_MATCHING_VERSION, naming the
-          # newest version it can see.
-          wranglerVersion: "4.127.0"
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           # Cloudflare deploys the project's production branch to the production URL
           # and every other branch to a preview of its own, so passing the branch
           # through is what makes a pull request preview appear.
-          command: >-
-            pages deploy dist
-            --project-name slidev-addon-fancy-arrow
-            --branch ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
-
-      # A branch deploy also gets an alias that stays put across pushes, which is the
-      # more useful link; production only has the one URL.
-      - name: Note where it went
-        if: ${{ steps.deploy.outputs.deployment-url != '' }}
-        env:
-          URL: ${{ steps.deploy.outputs.pages-deployment-alias-url || steps.deploy.outputs.deployment-url }}
-        run: echo "Deployed to $URL" >> "$GITHUB_STEP_SUMMARY"
+          BRANCH: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+        run: |
+          set -euo pipefail
+          # Run through pnpm rather than a third-party action so the install is
+          # covered by Safe Chain above, and pin the version for the same reason
+          # every action here is pinned. Bumping it means picking a release old
+          # enough that Safe Chain's minimum-age filter has let it through, which
+          # the newest one on the registry usually has not: an unreachable pin
+          # fails as ERR_PNPM_NO_MATCHING_VERSION, naming the newest it can see.
+          pnpm dlx wrangler@4.127.0 pages deploy dist \
+            --project-name slidev-addon-fancy-arrow \
+            --branch "$BRANCH" | tee deploy.log
+          # A branch deploy also gets an alias that stays put across pushes, which is
+          # the more useful link; production only prints the one URL. Both greps end
+          # in `|| true` because a miss is expected and would otherwise, under
+          # `pipefail`, end the step before the fallback runs.
+          url="$(grep -Eo 'alias URL: *https://[a-z0-9.-]+\.pages\.dev' deploy.log | grep -Eo 'https://.*' | tail -1 || true)"
+          if [ -z "$url" ]; then
+            url="$(grep -Eo 'https://[a-z0-9-]+\.[a-z0-9-]+\.pages\.dev' deploy.log | tail -1 || true)"
+          fi
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+          if [ -n "$url" ]; then
+            echo "Deployed $BRANCH to $url" >> "$GITHUB_STEP_SUMMARY"
+          else
+            # The deploy itself succeeded, so this is not worth failing the build over.
+            echo "Deployed $BRANCH, but could not read a URL out of wrangler's output." >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       # One comment that gets rewritten, rather than a new one per push.
       - name: Comment the preview URL
-        if: ${{ github.event_name == 'pull_request' && steps.deploy.outputs.deployment-url != '' }}
+        if: ${{ github.event_name == 'pull_request' && steps.deploy.outputs.url != '' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ github.event.pull_request.number }}
-          URL: ${{ steps.deploy.outputs.pages-deployment-alias-url || steps.deploy.outputs.deployment-url }}
+          URL: ${{ steps.deploy.outputs.url }}
           SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,47 +83,39 @@ jobs:
       - name: Deploy to Cloudflare Pages
         id: deploy
         if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # The action installs wrangler with this repository's own package manager,
+          # so Safe Chain covers it. Pin it as everything else here is pinned, to a
+          # release old enough for Safe Chain's minimum-age filter to have let it
+          # through: too new a pin fails as ERR_PNPM_NO_MATCHING_VERSION, naming the
+          # newest version it can see.
+          wranglerVersion: "4.127.0"
           # Cloudflare deploys the project's production branch to the production URL
           # and every other branch to a preview of its own, so passing the branch
           # through is what makes a pull request preview appear.
-          BRANCH: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
-        run: |
-          set -euo pipefail
-          # Run through pnpm rather than a third-party action so the install is
-          # covered by Safe Chain above, and pin the version for the same reason
-          # every action here is pinned. Bumping it means picking a release old
-          # enough that Safe Chain's minimum-age filter has let it through, which
-          # the newest one on the registry usually has not: an unreachable pin
-          # fails as ERR_PNPM_NO_MATCHING_VERSION, naming the newest it can see.
-          pnpm dlx wrangler@4.127.0 pages deploy dist \
-            --project-name slidev-addon-fancy-arrow \
-            --branch "$BRANCH" | tee deploy.log
-          # A branch deploy also gets an alias that stays put across pushes, which is
-          # the more useful link; production only prints the one URL. Both greps end
-          # in `|| true` because a miss is expected and would otherwise, under
-          # `pipefail`, end the step before the fallback runs.
-          url="$(grep -Eo 'alias URL: *https://[a-z0-9.-]+\.pages\.dev' deploy.log | grep -Eo 'https://.*' | tail -1 || true)"
-          if [ -z "$url" ]; then
-            url="$(grep -Eo 'https://[a-z0-9-]+\.[a-z0-9-]+\.pages\.dev' deploy.log | tail -1 || true)"
-          fi
-          echo "url=$url" >> "$GITHUB_OUTPUT"
-          if [ -n "$url" ]; then
-            echo "Deployed $BRANCH to $url" >> "$GITHUB_STEP_SUMMARY"
-          else
-            # The deploy itself succeeded, so this is not worth failing the build over.
-            echo "Deployed $BRANCH, but could not read a URL out of wrangler's output." >> "$GITHUB_STEP_SUMMARY"
-          fi
+          command: >-
+            pages deploy dist
+            --project-name slidev-addon-fancy-arrow
+            --branch ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+
+      # A branch deploy also gets an alias that stays put across pushes, which is the
+      # more useful link; production only has the one URL.
+      - name: Note where it went
+        if: ${{ steps.deploy.outputs.deployment-url != '' }}
+        env:
+          URL: ${{ steps.deploy.outputs.pages-deployment-alias-url || steps.deploy.outputs.deployment-url }}
+        run: echo "Deployed to $URL" >> "$GITHUB_STEP_SUMMARY"
 
       # One comment that gets rewritten, rather than a new one per push.
       - name: Comment the preview URL
-        if: ${{ github.event_name == 'pull_request' && steps.deploy.outputs.url != '' }}
+        if: ${{ github.event_name == 'pull_request' && steps.deploy.outputs.deployment-url != '' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ github.event.pull_request.number }}
-          URL: ${{ steps.deploy.outputs.url }}
+          URL: ${{ steps.deploy.outputs.pages-deployment-alias-url || steps.deploy.outputs.deployment-url }}
           SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,8 +94,11 @@ jobs:
           set -euo pipefail
           # Run through pnpm rather than a third-party action so the install is
           # covered by Safe Chain above, and pin the version for the same reason
-          # every action here is pinned.
-          pnpm dlx wrangler@4.127.1 pages deploy dist \
+          # every action here is pinned. Bumping it means picking a release old
+          # enough that Safe Chain's minimum-age filter has let it through, which
+          # the newest one on the registry usually has not: an unreachable pin
+          # fails as ERR_PNPM_NO_MATCHING_VERSION, naming the newest it can see.
+          pnpm dlx wrangler@4.127.0 pages deploy dist \
             --project-name slidev-addon-fancy-arrow \
             --branch "$BRANCH" | tee deploy.log
           # A branch deploy also gets an alias that stays put across pushes, which is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,14 @@ When modifying the `<FancyArrow>` component interface (props, slots, usage patte
 - `README.md` - User-facing documentation with usage examples
 - `slides.md` - Live demo slides that also serve as documentation
 
+## Deployment
+
+The demo deploys to Cloudflare Pages from the `build-demo` job in `.github/workflows/ci.yml`, which runs `wrangler pages deploy` against the `slidev-addon-fancy-arrow` project. A push to `main` updates production at <https://slidev-addon-fancy-arrow.pages.dev/>; every other branch gets a preview of its own, whose URL the job posts as a single comment on the pull request and rewrites on each push.
+
+That needs `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` as repository secrets. A pull request from a fork cannot read them, so it builds as a check and skips the deploy.
+
+The build takes no `--base`, since Cloudflare serves the demo from the root of its domain rather than a subdirectory.
+
 ## Cloud sessions
 
 A cloud session has no browser, so the only way to look at a slide is to render it to a PNG and read the image back.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ When modifying the `<FancyArrow>` component interface (props, slots, usage patte
 
 ## Deployment
 
-The demo deploys to Cloudflare Pages from the `build-demo` job in `.github/workflows/ci.yml`, which runs `wrangler pages deploy` against the `slidev-addon-fancy-arrow` project. A push to `main` updates production at <https://slidev-addon-fancy-arrow.pages.dev/>; every other branch gets a preview of its own, whose URL the job posts as a single comment on the pull request and rewrites on each push.
+The demo deploys to Cloudflare Pages from the `build-demo` job in `.github/workflows/ci.yml`, which runs `wrangler pages deploy` against the `slidev-addon-fancy-arrow` project through Cloudflare's own `wrangler-action`. A push to `main` updates production at <https://slidev-addon-fancy-arrow.pages.dev/>; every other branch gets a preview of its own, whose URL the job posts as a single comment on the pull request and rewrites on each push.
 
 That needs `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` as repository secrets. A pull request from a fork cannot read them, so it builds as a check and skips the deploy.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ When modifying the `<FancyArrow>` component interface (props, slots, usage patte
 
 ## Deployment
 
-The demo deploys to Cloudflare Pages from the `build-demo` job in `.github/workflows/ci.yml`, which runs `wrangler pages deploy` against the `slidev-addon-fancy-arrow` project through Cloudflare's own `wrangler-action`. A push to `main` updates production at <https://slidev-addon-fancy-arrow.pages.dev/>; every other branch gets a preview of its own, whose URL the job posts as a single comment on the pull request and rewrites on each push.
+The demo deploys to Cloudflare Pages from the `build-demo` job in `.github/workflows/ci.yml`, which runs `wrangler pages deploy` against the `slidev-addon-fancy-arrow` project. A push to `main` updates production at <https://slidev-addon-fancy-arrow.pages.dev/>; every other branch gets a preview of its own, whose URL the job posts as a single comment on the pull request and rewrites on each push.
 
 That needs `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` as repository secrets. A pull request from a fork cannot read them, so it builds as a check and skips the deploy.
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Slidev addon for adding fancy arrows to your slides, powered by [Rough.js](https
 
 [![NPM Version](https://img.shields.io/npm/v/slidev-addon-fancy-arrow)](https://www.npmjs.com/package/slidev-addon-fancy-arrow)
 
-[![Cover image](./assets/cover.png)](https://whitphx.github.io/slidev-addon-fancy-arrow/)
+[![Cover image](./assets/cover.png)](https://slidev-addon-fancy-arrow.pages.dev/)
 
-[👉 Check out the demo and docs](https://whitphx.github.io/slidev-addon-fancy-arrow/).
+[👉 Check out the demo and docs](https://slidev-addon-fancy-arrow.pages.dev/).
 
 ## Installation
 
@@ -29,7 +29,7 @@ See also: https://sli.dev/guide/theme-addon#use-addon
 
 ## Usage
 
-[👉 Check out the demo and docs](https://whitphx.github.io/slidev-addon-fancy-arrow/).
+[👉 Check out the demo and docs](https://slidev-addon-fancy-arrow.pages.dev/).
 
 ### Absolute positions
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,7 +5,14 @@ packages:
   - "."
 allowBuilds:
   esbuild: true
+  # wrangler pulls workerd, and `wrangler-action` installs wrangler into the project
+  # to deploy the demo, so an unapproved build script there stops the deploy: pnpm 11
+  # fails the install with ERR_PNPM_IGNORED_BUILDS rather than warning as pnpm 10 did.
+  # A Pages upload never runs the runtime binary this builds; it is approved so that
+  # installing wrangler succeeds.
+  workerd: true
 # pnpm 11 renamed `allowBuilds` from `onlyBuiltDependencies` and ignores the old key
 # without warning. Both are kept so the build runs on pnpm 9, 10 and 11 alike.
 onlyBuiltDependencies:
   - esbuild
+  - workerd

--- a/slides.md
+++ b/slides.md
@@ -46,7 +46,7 @@ the demo and docs!
 
 <div data-id="check-out" absolute right-50 top-20 text-2xl>
 
-[Check out](https://whitphx.github.io/slidev-addon-fancy-arrow/)
+[Check out](https://slidev-addon-fancy-arrow.pages.dev/)
 
 </div>
 


### PR DESCRIPTION
The demo lives at https://slidev-addon-fancy-arrow.pages.dev/ now, but CI still published to GitHub Pages. `deploy-demo` only ran on the default branch, so a pull request never had a preview to look at — the reason #433 has none. Cloudflare gives every branch one, which is the point of moving.

## What changed

**`build-demo` deploys what it just built,** through Cloudflare's `wrangler-action`, pinned by SHA like every other action here. No artifact is handed between jobs and no separate deploy job is left.

**Every branch gets a preview.** The branch name is passed to `pages deploy --branch`, so `main` updates production and anything else becomes its own preview. The URL is posted as a single pull request comment, rewritten on later pushes rather than added to, and also written to the job summary.

**`workerd`'s build script is approved** in `pnpm-workspace.yaml`. The action installs wrangler into the project with `pnpm add`, which pulls workerd, and pnpm 11 fails an install whose build scripts are not approved where pnpm 10 only warned. Its postinstall now runs, for a runtime binary a Pages upload never executes — the cost of using the action rather than driving wrangler by hand.

**The GitHub Pages base path is gone.** The build used to pass `--base` with the repository name, to serve from a subdirectory of `github.io`. Left in, every asset would point under `/slidev-addon-fancy-arrow/`, which does not exist on the Cloudflare domain. Without it, `dist/index.html` references `/assets/…` from the root.

**A fork's pull request builds but does not deploy.** It cannot read the secrets, so the deploy and comment steps are skipped rather than failing the check.

**Links repointed** — three in `README.md`, one in `slides.md`, plus a new "Deployment" section in `CLAUDE.md`.

## Verification

The deploy has run for real on this branch, several times. It produces the preview comment above and **rewrites it in place** on each push rather than duplicating it, which confirms both halves of the mechanism against the real thing.

That also settles what could not be tested locally: the token's scope, the project name, and that `pages-deployment-alias-url` populates — the comment links the stable branch address rather than a per-build hash. Cloudflare truncates the branch slug to 28 characters, which is why the URL comes from the action's output rather than being predicted.

The `workerd` change was reproduced before pushing, under the pnpm CI actually uses (11.24, from `version: latest`; a local 10.33 only warns and hides the problem):

| `pnpm-workspace.yaml` | `pnpm add wrangler@4.127.0` |
| --- | --- |
| `esbuild` only | `ERR_PNPM_IGNORED_BUILDS`, exit 1 — matches the failure in CI |
| `esbuild` + `workerd` | postinstall runs, exit 0 |

`pnpm install --frozen-lockfile` on this repo still exits 0 with the wider allowlist. `pnpm lint`, `pnpm format --check`, `pnpm test` (86/86) and `pnpm build` pass.

## History worth keeping

The deploy step was written by hand first, driving wrangler through `pnpm dlx` and reading the URL out of its stdout, because the action appeared to need a SHA that could not be resolved from where this was written. Two things came out of that detour and are recorded because both could recur:

- Pinning wrangler to the newest published version fails. Safe Chain suppresses releases below a minimum age, so `4.127.1` was invisible to the install and errored as `ERR_PNPM_NO_MATCHING_VERSION`, naming `4.127.0` as the newest it could see. The `wranglerVersion` input carries that pin, and the constraint is noted where it lives.
- The stdout parsing it replaced had a bug that only running it revealed: under `set -euo pipefail`, a `grep` miss exited 1 and ended the step before the fallback ran. The action's outputs remove that class of problem entirely, which is the main reason it is worth the `workerd` approval.

> [!NOTE]
> If Cloudflare's dashboard Git integration is connected to this repo, disconnect it, or every push deploys twice. Merging this deploys production from `main` for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Demo deployments now use Cloudflare Pages.
  * Pull requests receive preview deployment URLs, updated in a single comment.
  * Production deployments are available at the new Cloudflare Pages address.

* **Documentation**
  * Updated README and slide links to the new demo URL.
  * Added deployment guidance and preview behavior documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->