### PR TITLE
fix: Anchor an arrow to its slide instead of its containing block

### DIFF
--- a/.changeset/shiny-eyes-repeat.md
+++ b/.changeset/shiny-eyes-repeat.md
@@ -1,0 +1,5 @@
+---
+"slidev-addon-fancy-arrow": patch
+---
+
+Anchor an arrow to the slide it is on rather than to whatever the browser gives its SVG as a containing block, so positions stay right wherever the arrow sits in the markup. An arrow inside a positioned or transformed element, such as `<div class="relative">` or a `v-drag` container, used to draw `x1`/`y1`, `from="(x, y)"` and percentage positions offset by that element's own position, and to snap at the wrong scale when something between the slide and the arrow scaled it. The scale is now measured from the arrow's own SVG instead of taken from the slide's, which also fixes arrows on a slide with a `zoom` frontmatter.

--- a/components/FancyArrow.vue
+++ b/components/FancyArrow.vue
@@ -177,8 +177,16 @@ function getSnapTarget(
   return snapTarget;
 }
 
-const tailPosition = resolveSnapTargetPosition(svgContainer, tail);
-const headPosition = resolveSnapTargetPosition(svgContainer, head);
+const tailPosition = resolveSnapTargetPosition(
+  svgContainer,
+  slideContainer,
+  tail,
+);
+const headPosition = resolveSnapTargetPosition(
+  svgContainer,
+  slideContainer,
+  head,
+);
 
 const tailAbsPos = computeEndpointPosition(tailPosition, headPosition);
 const headAbsPos = computeEndpointPosition(headPosition, tailPosition);

--- a/components/arrow-frame.test.ts
+++ b/components/arrow-frame.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from "vitest";
+import {
+  measureArrowFrame,
+  screenToSvgPoint,
+  screenToSvgSize,
+  slideToSvgPoint,
+  type Rect,
+} from "./arrow-frame";
+
+const SLIDE_SIZE = { width: 980, height: 552 };
+
+/** The slide as it is displayed, and the SVG of an arrow placed directly on it. */
+function slideRect(scale: number, left = 0, top = 0): Rect {
+  return {
+    left,
+    top,
+    width: SLIDE_SIZE.width * scale,
+    height: SLIDE_SIZE.height * scale,
+  };
+}
+function svgRect(scale: number, left = 0, top = 0): Rect {
+  return { left, top, width: scale, height: scale };
+}
+
+describe("measureArrowFrame", () => {
+  it("takes the scale from the size of the 1px SVG", () => {
+    const frame = measureArrowFrame(
+      svgRect(0.5),
+      slideRect(0.5),
+      SLIDE_SIZE,
+      1,
+    );
+    expect(frame.scale).toEqual({ x: 0.5, y: 0.5 });
+  });
+
+  it("falls back to the given scale when the SVG has no size to measure", () => {
+    const frame = measureArrowFrame(
+      { left: 0, top: 0, width: 0, height: 0 },
+      undefined,
+      SLIDE_SIZE,
+      0.5,
+    );
+    expect(frame.scale).toEqual({ x: 0.5, y: 0.5 });
+  });
+
+  it("maps slide coordinates one to one when the arrow sits at the slide's origin", () => {
+    const frame = measureArrowFrame(
+      svgRect(0.5),
+      slideRect(0.5),
+      SLIDE_SIZE,
+      0.5,
+    );
+    expect(frame.slideOrigin).toEqual({ x: 0, y: 0 });
+    expect(frame.slideUnit).toEqual({ x: 1, y: 1 });
+    expect(slideToSvgPoint(frame, { x: 100, y: 200 })).toEqual({
+      x: 100,
+      y: 200,
+    });
+  });
+
+  it("keeps slide coordinates on the slide when a positioned ancestor moved the SVG", () => {
+    // The SVG is anchored to an ancestor 60px right and 40px down from the slide's
+    // top-left corner, on a slide displayed at half its authored size.
+    const frame = measureArrowFrame(
+      svgRect(0.5, 30, 20),
+      slideRect(0.5),
+      SLIDE_SIZE,
+      0.5,
+    );
+    expect(frame.slideOrigin).toEqual({ x: -60, y: -40 });
+    expect(frame.slideUnit).toEqual({ x: 1, y: 1 });
+    expect(slideToSvgPoint(frame, { x: 100, y: 200 })).toEqual({
+      x: 40,
+      y: 160,
+    });
+  });
+
+  it("keeps slide coordinates on the slide when an ancestor scales the SVG", () => {
+    // The arrow is inside something displayed at twice the scale of the slide itself,
+    // so one slide unit is half an SVG user unit.
+    const frame = measureArrowFrame(
+      svgRect(1),
+      slideRect(0.5),
+      SLIDE_SIZE,
+      0.5,
+    );
+    expect(frame.slideUnit).toEqual({ x: 0.5, y: 0.5 });
+    expect(slideToSvgPoint(frame, { x: 100, y: 200 })).toEqual({
+      x: 50,
+      y: 100,
+    });
+  });
+
+  it("leaves coordinates as they are when there is no slide to anchor to", () => {
+    const frame = measureArrowFrame(
+      svgRect(1, 30, 20),
+      undefined,
+      SLIDE_SIZE,
+      1,
+    );
+    expect(frame.slideOrigin).toEqual({ x: 0, y: 0 });
+    expect(frame.slideUnit).toEqual({ x: 1, y: 1 });
+    expect(slideToSvgPoint(frame, { x: 100, y: 200 })).toEqual({
+      x: 100,
+      y: 200,
+    });
+  });
+
+  it("ignores a slide that isn't being rendered", () => {
+    const frame = measureArrowFrame(
+      svgRect(1),
+      { left: 0, top: 0, width: 0, height: 0 },
+      SLIDE_SIZE,
+      1,
+    );
+    expect(frame.slideUnit).toEqual({ x: 1, y: 1 });
+  });
+});
+
+describe("screenToSvgPoint", () => {
+  it("measures from the SVG's own origin", () => {
+    const frame = measureArrowFrame(
+      svgRect(0.5, 30, 20),
+      slideRect(0.5),
+      SLIDE_SIZE,
+      0.5,
+    );
+    expect(screenToSvgPoint(frame, { x: 130, y: 70 })).toEqual({
+      x: 200,
+      y: 100,
+    });
+    expect(screenToSvgSize(frame, { x: 50, y: 25 })).toEqual({
+      x: 100,
+      y: 50,
+    });
+  });
+
+  it("puts a snapped point on the same screen pixel whatever moved the SVG", () => {
+    const target = { x: 130, y: 70 };
+    const toScreen = (svg: Rect) => {
+      const frame = measureArrowFrame(svg, slideRect(0.5), SLIDE_SIZE, 0.5);
+      const point = screenToSvgPoint(frame, target);
+      return {
+        x: svg.left + point.x * frame.scale.x,
+        y: svg.top + point.y * frame.scale.y,
+      };
+    };
+    expect(toScreen(svgRect(0.5))).toEqual(target);
+    expect(toScreen(svgRect(0.5, 30, 20))).toEqual(target);
+  });
+});

--- a/components/arrow-frame.ts
+++ b/components/arrow-frame.ts
@@ -1,0 +1,113 @@
+/**
+ * The mapping between the three coordinate systems an arrow deals with:
+ *
+ * - **screen**: what `getBoundingClientRect()` returns, which is where the elements an
+ *   arrow snaps to are measured.
+ * - **SVG user units**: what the arrow is actually drawn in. The arrow's `<svg>` is a
+ *   1px x 1px box placed at the top-left corner of its containing block, which is the
+ *   nearest positioned or transformed ancestor rather than the slide. So its origin is
+ *   wherever that ancestor happens to be.
+ * - **slide**: what `x1`/`y1`, `(x, y)` and percentages are written in, whose origin is
+ *   the top-left corner of the slide and whose unit is one of the `slideWidth` x
+ *   `slideHeight` pixels the slide is authored at.
+ *
+ * The three only coincide when the arrow sits directly in the slide and the slide is
+ * displayed at its authored size, so every coordinate is converted through the frame
+ * measured here instead of assumed.
+ */
+
+export interface Rect {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+export interface ArrowFrame {
+  /** Screen pixels per SVG user unit. */
+  scale: Point;
+  /** The SVG's origin, in screen coordinates. */
+  screenOrigin: Point;
+  /** The slide's top-left corner, in SVG user units. */
+  slideOrigin: Point;
+  /** SVG user units per slide coordinate unit. */
+  slideUnit: Point;
+}
+
+/**
+ * @param svgRect the arrow's `<svg>` element, which is laid out as a 1px x 1px box.
+ * @param slideRect the slide element the arrow is on, or `undefined` when the arrow is
+ * used outside a slide.
+ * @param slideSize the size the slide is authored at.
+ * @param fallbackScale the scale to assume when the SVG has no size to measure.
+ */
+export function measureArrowFrame(
+  svgRect: Rect,
+  slideRect: Rect | undefined,
+  slideSize: { width: number; height: number },
+  fallbackScale: number,
+): ArrowFrame {
+  // The SVG is one pixel wide and one pixel tall, so its measured size is how much
+  // screen space one of its user units takes up. Measuring it beats deriving it from
+  // the slide's scale, because it also accounts for whatever the elements between the
+  // slide and the arrow do, such as a `zoom` or a `transform: scale()`.
+  // A zero size means it isn't being rendered at all and there is nothing to measure.
+  const scale = {
+    x: svgRect.width > 0 ? svgRect.width : fallbackScale,
+    y: svgRect.height > 0 ? svgRect.height : fallbackScale,
+  };
+  const screenOrigin = { x: svgRect.left, y: svgRect.top };
+
+  if (slideRect == null || slideRect.width <= 0 || slideRect.height <= 0) {
+    // Without a slide to anchor to there is nothing better to treat as its origin than
+    // the SVG's own, which is what the arrow is drawn relative to anyway.
+    return {
+      scale,
+      screenOrigin,
+      slideOrigin: { x: 0, y: 0 },
+      slideUnit: { x: 1, y: 1 },
+    };
+  }
+
+  return {
+    scale,
+    screenOrigin,
+    slideOrigin: {
+      x: (slideRect.left - svgRect.left) / scale.x,
+      y: (slideRect.top - svgRect.top) / scale.y,
+    },
+    slideUnit: {
+      x: slideRect.width / slideSize.width / scale.x,
+      y: slideRect.height / slideSize.height / scale.y,
+    },
+  };
+}
+
+/** Converts a point measured with `getBoundingClientRect()` into SVG user units. */
+export function screenToSvgPoint(frame: ArrowFrame, point: Point): Point {
+  return {
+    x: (point.x - frame.screenOrigin.x) / frame.scale.x,
+    y: (point.y - frame.screenOrigin.y) / frame.scale.y,
+  };
+}
+
+/** Converts a size measured with `getBoundingClientRect()` into SVG user units. */
+export function screenToSvgSize(frame: ArrowFrame, size: Point): Point {
+  return {
+    x: size.x / frame.scale.x,
+    y: size.y / frame.scale.y,
+  };
+}
+
+/** Converts a point written in slide coordinates into SVG user units. */
+export function slideToSvgPoint(frame: ArrowFrame, point: Point): Point {
+  return {
+    x: frame.slideOrigin.x + point.x * frame.slideUnit.x,
+    y: frame.slideOrigin.y + point.y * frame.slideUnit.y,
+  };
+}

--- a/components/position.ts
+++ b/components/position.ts
@@ -19,6 +19,13 @@ import type {
   SnapAnchorPoint,
 } from "./parse-option";
 import { getClosestEdgePoint } from "./closest-edge-point";
+import {
+  measureArrowFrame,
+  screenToSvgPoint,
+  screenToSvgSize,
+  slideToSvgPoint,
+  type ArrowFrame,
+} from "./arrow-frame";
 
 function getAbsoluteValue(
   lengthPercentage: LengthPercentage,
@@ -76,77 +83,124 @@ export interface BoxPosition {
   snapPosition: SnapAnchorPoint | Position | undefined;
 }
 
+/**
+ * The position of one endpoint, in the SVG user units the arrow is drawn in:
+ * either the point itself, or the box it snaps to.
+ */
+export type ResolvedPosition = AbsolutePosition | BoxPosition;
+
+function resolveAbsolutePosition(
+  position: Position,
+  frame: ArrowFrame,
+): AbsolutePosition {
+  return slideToSvgPoint(frame, {
+    x: getAbsoluteValue(position.x, slideWidth.value),
+    y: getAbsoluteValue(position.y, slideHeight.value),
+  });
+}
+
+function resolveSnappedPosition(
+  snapTarget: SnapTarget,
+  frame: ArrowFrame,
+): BoxPosition | undefined {
+  const rect = getUnionRect(snapTarget.elements);
+  if (rect == null) {
+    return undefined;
+  }
+
+  const { x, y } = screenToSvgPoint(frame, { x: rect.left, y: rect.top });
+  const { x: width, y: height } = screenToSvgSize(frame, {
+    x: rect.right - rect.left,
+    y: rect.bottom - rect.top,
+  });
+  return {
+    rect: { x, y, width, height },
+    snapPosition: snapTarget.snapPosition,
+  };
+}
+
+function isSamePosition(
+  a: ResolvedPosition | undefined,
+  b: ResolvedPosition | undefined,
+): boolean {
+  if (a == null || b == null) {
+    return a === b;
+  }
+  if ("x" in a) {
+    return "x" in b && a.x === b.x && a.y === b.y;
+  }
+  return (
+    !("x" in b) &&
+    a.snapPosition === b.snapPosition &&
+    a.rect.x === b.rect.x &&
+    a.rect.y === b.rect.y &&
+    a.rect.width === b.rect.width &&
+    a.rect.height === b.rect.height
+  );
+}
+
+/**
+ * @param rootElementRef the arrow's own `<svg>` element.
+ * @param slideElementRef the slide the arrow is on, which the coordinates the arrow is
+ * given in are relative to.
+ * @param endpointRef the endpoint to resolve.
+ */
 export function resolveSnapTargetPosition(
   rootElementRef: Ref<SVGSVGElement | undefined>,
+  slideElementRef: Ref<Element | undefined>,
   endpointRef: Ref<Position | SnapTarget | undefined>,
-): Ref<Position | BoxPosition | undefined> {
+): Ref<ResolvedPosition | undefined> {
   const { $scale } = useSlideContext();
   const isSlideActive = useIsSlideActive();
 
-  // Sync SnapTarget -> BoxPosition in case where endpoint is SnapTarget
-  const position = ref<Position | BoxPosition | undefined>(undefined);
-  const updateSnappedPosition = () => {
-    if (endpointRef.value == null) {
-      return;
-    }
-    if ("x" in endpointRef.value) {
-      // Endpoint is of type Position
-      // so we don't need to update point in this method
-      // as it's done in the watch below.
+  const position = ref<ResolvedPosition | undefined>(undefined);
+  const updatePosition = () => {
+    const endpoint = endpointRef.value;
+    if (endpoint == null) {
       return;
     }
 
-    const snapTarget = endpointRef.value;
-
-    const { elements, snapPosition } = snapTarget;
-    const rect = getUnionRect(elements);
-    if (!rootElementRef.value || !rect) {
+    const rootElement = rootElementRef.value;
+    if (rootElement == null) {
       position.value = undefined;
       return;
     }
 
-    const rootRect = rootElementRef.value.getBoundingClientRect();
+    const frame = measureArrowFrame(
+      rootElement.getBoundingClientRect(),
+      slideElementRef.value?.getBoundingClientRect(),
+      { width: slideWidth.value, height: slideHeight.value },
+      $scale.value,
+    );
 
-    const x = (rect.left - rootRect.left) / $scale.value;
-    const y = (rect.top - rootRect.top) / $scale.value;
-    const width = (rect.right - rect.left) / $scale.value;
-    const height = (rect.bottom - rect.top) / $scale.value;
+    const newPosition =
+      "x" in endpoint
+        ? resolveAbsolutePosition(endpoint, frame)
+        : resolveSnappedPosition(endpoint, frame);
 
-    if (
-      position.value &&
-      "rect" in position.value &&
-      position.value.rect.x === x &&
-      position.value.rect.y === y &&
-      position.value.rect.width === width &&
-      position.value.rect.height === height
-    ) {
-      // Avoid unnecessary re-renders
+    if (isSamePosition(position.value, newPosition)) {
+      // This check is important.
+      // If the position/size of the element doesn't change,
+      // we must not update the ref to avoid unnecessary re-renders.
       return;
     }
-    position.value = {
-      rect: { x, y, width, height },
-      snapPosition,
-    };
+    position.value = newPosition;
   };
 
   watch(isSlideActive, () => {
     setTimeout(() => {
-      // This `setTimeout` is important to ensure `update()` is called after the DOM elements in the slide are updated after `isSlideActive` is changed.
-      updateSnappedPosition();
+      // This `setTimeout` is important to ensure `updatePosition()` is called after the DOM elements in the slide are updated after `isSlideActive` is changed.
+      updatePosition();
     });
   });
 
   watch(
     endpointRef,
     (newVal) => {
-      if (newVal == null) {
-        return;
-      }
-      if ("x" in newVal) {
-        // Sync Position -> Position
-        position.value = newVal;
-      } else if (newVal.elements.length > 0) {
-        const observer = new MutationObserver(updateSnappedPosition);
+      updatePosition();
+
+      if (newVal != null && !("x" in newVal) && newVal.elements.length > 0) {
+        const observer = new MutationObserver(updatePosition);
         newVal.elements.forEach((element) => {
           observer.observe(element, { attributes: true });
         });
@@ -160,12 +214,12 @@ export function resolveSnapTargetPosition(
   );
 
   onMounted(() => {
-    updateSnappedPosition();
+    updatePosition();
 
     // Some type of position/size changes can't be observed by MutationObserver.
     // So we need to update the position/size periodically in the polling manner.
     const interval = setInterval(() => {
-      updateSnappedPosition();
+      updatePosition();
     }, 100);
 
     return () => clearInterval(interval);
@@ -175,64 +229,61 @@ export function resolveSnapTargetPosition(
 }
 
 export function computeEndpointPosition(
-  position: Ref<Position | BoxPosition | undefined>,
-  anotherPosition: Ref<Position | BoxPosition | undefined>,
+  position: Ref<ResolvedPosition | undefined>,
+  anotherPosition: Ref<ResolvedPosition | undefined>,
 ): Ref<AbsolutePosition | undefined> {
   return computed<AbsolutePosition | undefined>((previous) => {
     if (position.value == null) {
       return undefined;
     }
     if ("x" in position.value) {
-      return {
-        x: getAbsoluteValue(position.value.x, slideWidth.value),
-        y: getAbsoluteValue(position.value.y, slideHeight.value),
-      };
-    } else {
-      const { snapPosition, rect } = position.value;
-      let x = rect.x;
-      let y = rect.y;
-      if (snapPosition == null) {
-        if (anotherPosition.value) {
-          // Auto snap to the point that is on the edge of the rectangle and closest to the center of the other element
-          const c2x =
-            "x" in anotherPosition.value
-              ? getAbsoluteValue(anotherPosition.value.x, slideWidth.value)
-              : anotherPosition.value.rect.x +
-                anotherPosition.value.rect.width / 2;
-          const c2y =
-            "y" in anotherPosition.value
-              ? getAbsoluteValue(anotherPosition.value.y, slideHeight.value)
-              : anotherPosition.value.rect.y +
-                anotherPosition.value.rect.height / 2;
-          const closestPoint = getClosestEdgePoint(rect, { x: c2x, y: c2y });
-          x = closestPoint.x;
-          y = closestPoint.y;
-        }
-      }
-      if (typeof snapPosition === "string") {
-        if (snapPosition.includes("right")) {
-          x += rect.width;
-        } else if (!snapPosition.includes("left")) {
-          x += rect.width / 2;
-        }
-        if (snapPosition.includes("bottom")) {
-          y += rect.height;
-        } else if (!snapPosition.includes("top")) {
-          y += rect.height / 2;
-        }
-      } else if (typeof snapPosition === "object") {
-        x += getAbsoluteValue(snapPosition.x, rect.width);
-        y += getAbsoluteValue(snapPosition.y, rect.height);
-      }
-
-      if (previous?.x === x && previous?.y === y) {
-        // This if-condition is important.
-        // If the position/size of the element doesn't change,
-        // we must not update the computed ref to avoid unnecessary re-renders.
-        return previous;
-      }
-
-      return { x, y };
+      return position.value;
     }
+
+    const { snapPosition, rect } = position.value;
+    let x = rect.x;
+    let y = rect.y;
+    if (snapPosition == null) {
+      if (anotherPosition.value) {
+        // Auto snap to the point that is on the edge of the rectangle and closest to the center of the other element
+        const c2x =
+          "x" in anotherPosition.value
+            ? anotherPosition.value.x
+            : anotherPosition.value.rect.x +
+              anotherPosition.value.rect.width / 2;
+        const c2y =
+          "x" in anotherPosition.value
+            ? anotherPosition.value.y
+            : anotherPosition.value.rect.y +
+              anotherPosition.value.rect.height / 2;
+        const closestPoint = getClosestEdgePoint(rect, { x: c2x, y: c2y });
+        x = closestPoint.x;
+        y = closestPoint.y;
+      }
+    }
+    if (typeof snapPosition === "string") {
+      if (snapPosition.includes("right")) {
+        x += rect.width;
+      } else if (!snapPosition.includes("left")) {
+        x += rect.width / 2;
+      }
+      if (snapPosition.includes("bottom")) {
+        y += rect.height;
+      } else if (!snapPosition.includes("top")) {
+        y += rect.height / 2;
+      }
+    } else if (typeof snapPosition === "object") {
+      x += getAbsoluteValue(snapPosition.x, rect.width);
+      y += getAbsoluteValue(snapPosition.y, rect.height);
+    }
+
+    if (previous?.x === x && previous?.y === y) {
+      // This if-condition is important.
+      // If the position/size of the element doesn't change,
+      // we must not update the computed ref to avoid unnecessary re-renders.
+      return previous;
+    }
+
+    return { x, y };
   });
 }


### PR DESCRIPTION
Towards #86.

## The bug

An arrow's `<svg>` is `position: absolute`, so the browser lays it out at the top-left corner of its **containing block** — the nearest positioned or transformed ancestor — which is the slide only when nothing between the arrow and the slide happens to be one. The coordinates `x1`/`y1`, `from="(x, y)"` and percentages are written in are slide coordinates, but they were handed to that SVG unchanged, so an arrow inside something like `<div class="relative">`, a `v-drag` container, or any transformed wrapper drew them offset by that wrapper's own position. The scale had the same shape of problem: it came from Slidev's slide scale, so anything scaling the arrow between the slide and itself (a `transform: scale()` wrapper, or a slide with a `zoom` frontmatter) stretched the result.

Which elements establish a containing block is also a place where engines differ (`filter`, `will-change`, `contain`, view transitions, …), which fits #86: the same deck coming out right in one browser and wrong in another, and a reporter working around it by adding `position: relative`.

Reproduced on Chromium 141 / Linux with a slide holding

```html
<div style="position: relative; left: 200px; top: 150px">
  <FancyArrow x1="500" y1="100" x2="100" y2="300" static />
</div>
```

which drew the arrow 200px right and 150px down from where it was asked to be.

## The fix

`components/arrow-frame.ts` is a new pure module that measures the mapping between the three coordinate systems an arrow deals with — screen (what `getBoundingClientRect()` returns), the SVG's user units (what the arrow is drawn in), and slide coordinates (what the props are written in) — and `position.ts` converts through it:

- The slide's origin is measured against the SVG's, so slide coordinates land on the slide wherever the SVG got anchored.
- The scale comes from the SVG's own box. It is laid out as 1px × 1px, so its measured size *is* how much screen space one user unit takes, whatever the slide and everything under it do to the arrow. Slidev's `$scale` stays as the fallback for when the SVG has no size to measure.
- Snapped endpoints keep being measured against the SVG itself, which was already right, and now use the measured scale instead of the slide's.

An arrow with no slide around it (`.slidev-page` missing) keeps its coordinates as they are, which is what it did before.

## Verification

- `pnpm test` (117 tests, including the new `components/arrow-frame.test.ts`), `pnpm lint`, `pnpm format --check`, `pnpm build`.
- Rendered the demo deck in headless Chromium before and after: existing slides are unchanged, and the repro above now draws where it is told. On a `zoom: 0.7` slide, an arrow from `(0, 0)` to `(980, 552)` now spans the slide corner to corner; before it stopped at 70% of it. An arrow inside a `transform: scale(1.5)` wrapper now snaps to its target instead of overshooting by half.

I could not reproduce the exact deck from #86 (the screenshots there are not reachable from this environment), so this fixes a definite cause of that class of symptom rather than a confirmed one. Worth asking the reporter to re-check once released.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtH2tR7qZzwTwGo9iqxCM9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected arrow positioning and scaling when arrows appear inside positioned or transformed elements, such as draggable containers.
  * Fixed arrow alignment on slides using zoom settings.
  * Ensured arrows remain anchored to their slide rather than shifting based on surrounding elements.

* **Tests**
  * Added coverage for coordinate conversion, scaling, positioning, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->